### PR TITLE
fix: bg_colour/colour order issue in PowerPoint format

### DIFF
--- a/_extensions/highlight-text/_extension.yml
+++ b/_extensions/highlight-text/_extension.yml
@@ -1,6 +1,6 @@
 title: Highlight Text
 author: Mickaël Canouil
-version: 0.4.0
+version: 1.0.0
 quarto-required: ">=1.4.550"
 contributes:
   filters:

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -87,11 +87,11 @@ end
 
 local function highlight_openxml_pptx(span, colour, bg_colour)
   local spec = '<a:r><a:rPr dirty="0">'
-  if bg_colour ~= nil then
-    spec = spec .. '<a:highlight><a:srgbClr val="' .. bg_colour:gsub("^#", "") .. '" /></a:highlight>'
-  end
   if colour ~= nil then
     spec = spec .. '<a:solidFill><a:srgbClr val="' .. colour:gsub("^#", "") .. '" /></a:solidFill>'
+  end
+  if bg_colour ~= nil then
+    spec = spec .. '<a:highlight><a:srgbClr val="' .. bg_colour:gsub("^#", "") .. '" /></a:highlight>'
   end
   spec = spec .. '</a:rPr><a:t>'
 


### PR DESCRIPTION
The order of the bg_colour and colour attributes in the `highlight_openxml_pptx` function was causing an issue where the colour attribute was not being added when both attributes were specified. This pull request fixes the issue by switching the order of the attributes in the function (thanks @bhelsel).

Additionally, the version of the extension has been bumped to 1.0.0 (finally).

Fixes #16