### PR TITLE
fix: PDF text highlight should work with line breaks

### DIFF
--- a/_extensions/highlight-text/_extension.yml
+++ b/_extensions/highlight-text/_extension.yml
@@ -1,6 +1,6 @@
 title: Highlight Text
 author: Mickaël Canouil
-version: 1.0.0
+version: 1.0.1
 quarto-required: ">=1.4.550"
 contributes:
   filters:

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -56,7 +56,7 @@ local function highlight_latex(span, colour, bg_colour)
     bg_colour_open = ''
     bg_colour_close = ''
   else
-    bg_colour_open = '\\fcolorbox[HTML]{' .. bg_colour:gsub("^#", "") .. '}{\\parbox{\\linewidth}{'
+    bg_colour_open = '\\colorbox[HTML]{' .. bg_colour:gsub("^#", "") .. '}{\\parbox{\\linewidth}{'
     bg_colour_close = '}}'
   end
 

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -56,8 +56,8 @@ local function highlight_latex(span, colour, bg_colour)
     bg_colour_open = ''
     bg_colour_close = ''
   else
-    bg_colour_open = '\\colorbox[HTML]{' .. bg_colour:gsub("^#", "") .. '}{'
-    bg_colour_close = '}'
+    bg_colour_open = '\\fcolorbox[HTML]{' .. bg_colour:gsub("^#", "") .. '}{\\parbox{\\linewidth}{'
+    bg_colour_close = '}}'
   end
 
   table.insert(

--- a/example.qmd
+++ b/example.qmd
@@ -116,15 +116,3 @@ Then you can use the span syntax markup to highlight text in your document.
 [text [with a link](https://quarto.org/)]{
   color="#FFFFFF" bg-color="#00FFFF"
 }
-
-## Line Breaks in Highlighted Text
-
-```markdown
-[{{< lipsum 1 >}}]{
-  color="#FFFFFF" bg-color="#FF5733"
-}
-```
-
-[{{< lipsum 1 >}}]{
-  color="#FFFFFF" bg-color="#FF5733"
-}

--- a/example.qmd
+++ b/example.qmd
@@ -116,3 +116,15 @@ Then you can use the span syntax markup to highlight text in your document.
 [text [with a link](https://quarto.org/)]{
   color="#FFFFFF" bg-color="#00FFFF"
 }
+
+## Line Breaks in Highlighted Text
+
+```markdown
+[{{< lipsum 1 >}}]{
+  color="#FFFFFF" bg-color="#FF5733"
+}
+```
+
+[{{< lipsum 1 >}}]{
+  color="#FFFFFF" bg-color="#FF5733"
+}


### PR DESCRIPTION
Fixes #18

Modify the `highlight_latex` function to support line breaks in highlighted text in PDF.

* Change `\colorbox` to `\fcolorbox` and `\parbox` in `_extensions/highlight-text/highlight-text.lua` to handle line breaks within highlighted text.
* Add a new section in `example.qmd` to test line breaks in highlighted text with a long text example.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mcanouil/quarto-highlight-text/pull/19?shareId=b2cf9279-9d18-4985-9fbd-0d18f020efb5).