### PR TITLE
feat: add support for `_brand.yml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ Then you can use the span syntax markup to highlight text in your document, *e.g
 [Blue]{color="#0000FF" bg-color="#ABC123"} # US
 ```
 
+Using colours from `_brand.yml`:
+
+```markdown
+brand:
+  color:
+    palette:
+      red: "#b22222"
+    primary: "#abc123"
+```
+
+```markdown
+[Red]{colour="brand-color.red" bg-colour="brand-color.primary"}
+```
+
 ## Examples
 
 Here is the source code for a minimal example: [`example.qmd`](example.qmd).

--- a/_extensions/highlight-text/_extension.yml
+++ b/_extensions/highlight-text/_extension.yml
@@ -1,7 +1,7 @@
 title: Highlight Text
 author: Mickaël Canouil
-version: 1.0.1
-quarto-required: ">=1.4.550"
+version: 1.1.0
+quarto-required: ">=1.6.37"
 contributes:
   filters:
     - highlight-text.lua

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -146,6 +146,14 @@ function Span(span)
     bg_colour = span.attributes['bg-color']
   end
 
+  local brand = require('modules/brand/brand')
+  if colour and colour:match("^brand%-color.") then
+    colour = brand.get_color(colour:gsub("^brand%-color%.", ""))
+  end
+  if bg_colour and bg_colour:match("^brand%-color.") then
+    bg_colour = brand.get_color(bg_colour:gsub("^brand%-color%.", ""))
+  end
+
   if colour == nil and bg_colour == nil then return span end
 
   if FORMAT:match 'html' or FORMAT:match 'revealjs' then

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -22,6 +22,18 @@
 # SOFTWARE.
 ]]
 
+local function get_brand_color(colour)
+  local brand = require('modules/brand/brand')
+  if colour and colour:match("^brand%-color.") then
+    colour = brand.get_color(colour:gsub("^brand%-color%.", ""))
+  else
+    if FORMAT:match 'typst' and colour  ~= nil then
+      colour = 'rgb("' .. colour .. '")'
+    end
+  end
+  return colour
+end
+
 local function highlight_html(span, colour, bg_colour)
   if span.attributes['style'] == nil then
     span.attributes['style'] = ''
@@ -111,7 +123,7 @@ local function highlight_typst(span, colour, bg_colour)
     colour_open = ''
     colour_close = ''
   else
-    colour_open = '#text(rgb("' .. colour .. '"))['
+    colour_open = '#text(' .. colour .. ')['
     colour_close = ']'
   end
 
@@ -119,7 +131,7 @@ local function highlight_typst(span, colour, bg_colour)
     bg_colour_open = ''
     bg_colour_close = ''
   else
-    bg_colour_open = '#highlight(fill: rgb("' .. bg_colour .. '"))['
+    bg_colour_open = '#highlight(fill: ' .. bg_colour .. ')['
     bg_colour_close = ']'
   end
 
@@ -146,15 +158,10 @@ function Span(span)
     bg_colour = span.attributes['bg-color']
   end
 
-  local brand = require('modules/brand/brand')
-  if colour and colour:match("^brand%-color.") then
-    colour = brand.get_color(colour:gsub("^brand%-color%.", ""))
-  end
-  if bg_colour and bg_colour:match("^brand%-color.") then
-    bg_colour = brand.get_color(bg_colour:gsub("^brand%-color%.", ""))
-  end
-
   if colour == nil and bg_colour == nil then return span end
+
+  colour = get_brand_color(colour)
+  bg_colour = get_brand_color(bg_colour)
 
   if FORMAT:match 'html' or FORMAT:match 'revealjs' then
     return highlight_html(span, colour, bg_colour)

--- a/example.qmd
+++ b/example.qmd
@@ -30,6 +30,12 @@ execute:
   echo: true
 filters:
   - highlight-text
+brand:
+  color:
+    palette:
+      blue: "#0000ff"
+      red: "#b22222"
+    primary: "#ffffff"
 ---
 
 This is a Quarto extension that allows to highlight text in a document for various format: HTML, LaTeX, Typst, and Docx.
@@ -116,3 +122,21 @@ Then you can use the span syntax markup to highlight text in your document.
 [text [with a link](https://quarto.org/)]{
   color="#FFFFFF" bg-color="#00FFFF"
 }
+
+## `_brand.yml`
+
+```markdown
+[White text, Red background]{
+  colour="brand-color.primary" bg-colour="brand-color.red"
+}
+```
+
+[White text, Red background]{colour="brand-color.primary" bg-colour="brand-color.red"}
+
+```markdown
+[White text, Blue background]{
+  color="brand-color.primary" bg-color="brand-color.blue"
+}
+```
+
+[White text, Blue background]{color="brand-color.primary" bg-color="brand-color.blue"}


### PR DESCRIPTION
Introduce support for `_brand.yml` to allow the use of brand colors in text highlighting. Update the extension to retrieve colors defined in `_brand.yml`, and enhance documentation with examples of usage.

Fixes #20