### PR TITLE
fix: all line highlighted in LaTeX formats

### DIFF
--- a/_extensions/highlight-text/_extension.yml
+++ b/_extensions/highlight-text/_extension.yml
@@ -1,6 +1,6 @@
 title: Highlight Text
 author: Mickaël Canouil
-version: 1.1.1
+version: 1.1.2
 quarto-required: ">=1.6.37"
 contributes:
   filters:

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -74,7 +74,7 @@ local function highlight_latex(span, colour, bg_colour)
 
   table.insert(
     span.content, 1,
-    pandoc.RawInline('latex', colour_open .. bg_colour_open)
+    pandoc.RawInline('latex', "{" .. colour_open .. bg_colour_open .. "}")
   )
   table.insert(span.content, pandoc.RawInline('latex', bg_colour_close .. colour_close))
 


### PR DESCRIPTION
Adjustments ensure that highlighting applies to the full line rather than just the selected span. Fixes issue #24.