### PR TITLE
fix: add "par" attribute for LaTeX text with line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ color:
 
 ## Limitations
 
-LaTeX `\colorbox` command does not support linebreaks in the text to be highlighted.
-This means that the above example will not work in LaTeX output.  
-In order to get a slightly better result, you can use the following syntax `par=true` to add `\parbox{\linewidth}`:
+LaTeX `\colorbox` command does not support wrapping/line breaks in the text to be highlighted.
+This means that the above example will not work well in LaTeX output.  
+In order to get a slightly better result, you can use the `par=true` attribute to add `\parbox{\linewidth}`:
 
 ```markdown
 [Red]{colour="#b22222" bg-colour="#abc123" par=true}

--- a/README.md
+++ b/README.md
@@ -36,15 +36,24 @@ You can also use the shorter syntax ([v1.1.1](../../releases/tag/1.1.1)):
 Using colours from `_brand.yml` ([v1.1.0](../../releases/tag/1.1.0)):
 
 ```markdown
-brand:
-  color:
-    palette:
-      red: "#b22222"
-    primary: "#abc123"
+color:
+  palette:
+    red: "#b22222"
+  primary: "#abc123"
 ```
 
 ```markdown
 [Red]{colour="brand-color.red" bg-colour="brand-color.primary"}
+```
+
+## Limitations
+
+LaTeX `\colorbox` command does not support linebreaks in the text to be highlighted.
+This means that the above example will not work in LaTeX output.  
+In order to get a slightly better result, you can use the following syntax `par=true` to add `\parbox{\linewidth}`:
+
+```markdown
+[Red]{colour="#b22222" bg-colour="#abc123" par=true}
 ```
 
 ## Examples

--- a/_extensions/highlight-text/_extension.yml
+++ b/_extensions/highlight-text/_extension.yml
@@ -1,6 +1,6 @@
 title: Highlight Text
 author: Mickaël Canouil
-version: 1.1.2
+version: 1.1.3
 quarto-required: ">=1.6.37"
 contributes:
   filters:

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -56,7 +56,7 @@ local function highlight_html(span, colour, bg_colour)
   return span
 end
 
-local function highlight_latex(span, colour, bg_colour)
+local function highlight_latex(span, colour, bg_colour, par)
   if colour == nil then
     colour_open = ''
     colour_close = ''
@@ -68,13 +68,18 @@ local function highlight_latex(span, colour, bg_colour)
     bg_colour_open = ''
     bg_colour_close = ''
   else
-    bg_colour_open = '\\colorbox[HTML]{' .. bg_colour:gsub("^#", "") .. '}{\\parbox{\\linewidth}{'
-    bg_colour_close = '}}'
+    bg_colour_open = '\\colorbox[HTML]{' .. bg_colour:gsub("^#", "") .. '}{'
+    bg_colour_close = '}'
+  end
+
+  if par then
+    bg_colour_open = bg_colour_open .. '\\parbox{\\linewidth}{'
+    bg_colour_close = '}' .. bg_colour_close
   end
 
   table.insert(
     span.content, 1,
-    pandoc.RawInline('latex', "{" .. colour_open .. bg_colour_open .. "}")
+    pandoc.RawInline('latex', "{" .. colour_open .. bg_colour_open)
   )
   table.insert(span.content, pandoc.RawInline('latex', bg_colour_close .. colour_close))
 
@@ -169,10 +174,17 @@ function Span(span)
   colour = get_brand_color(colour)
   bg_colour = get_brand_color(bg_colour)
 
+  if span.attributes['par'] == nil then
+    par = false
+  else
+    par = true
+    span.attributes['par'] = nil
+  end
+
   if FORMAT:match 'html' or FORMAT:match 'revealjs' then
     return highlight_html(span, colour, bg_colour)
   elseif FORMAT:match 'latex' or FORMAT:match 'beamer' then
-    return highlight_latex(span, colour, bg_colour)
+    return highlight_latex(span, colour, bg_colour, par)
   elseif FORMAT:match 'docx' then
     return highlight_openxml_docx(span, colour, bg_colour)
   elseif FORMAT:match 'pptx' then

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -79,7 +79,7 @@ local function highlight_latex(span, colour, bg_colour, par)
 
   table.insert(
     span.content, 1,
-    pandoc.RawInline('latex', "{" .. colour_open .. bg_colour_open)
+    pandoc.RawInline('latex', colour_open .. bg_colour_open)
   )
   table.insert(span.content, pandoc.RawInline('latex', bg_colour_close .. colour_close))
 

--- a/example.qmd
+++ b/example.qmd
@@ -141,3 +141,27 @@ Then you can use the span syntax markup to highlight text in your document.
 ```
 
 [White text, Blue background]{color="brand-color.primary" bg-color="brand-color.blue"}
+
+## Limitations
+
+LaTeX `\colorbox` command does not support wrapping/line breaks in the text to be highlighted.
+This means that the above example will not work well in LaTeX output.
+
+```markdown
+[Your long text]{colour="#b22222" bg-colour="#abc123"}
+```
+[
+  LaTeX `\colorbox` command does not support wrapping/line breaks in the text to be highlighted.
+This means that the above example will not work well in LaTeX output.
+]{colour="#b22222" bg-colour="#abc123"}
+
+In order to get a slightly better result, you can use the `par=true` attribute to add `\parbox{\linewidth}`:
+
+```markdown
+[Your long text]{colour="#b22222" bg-colour="#abc123" par=true}
+```
+
+[
+  LaTeX `\colorbox` command does not support wrapping/line breaks in the text to be highlighted.
+This means that the above example will not work well in LaTeX output.
+]{colour="#b22222" bg-colour="#abc123" par=true}


### PR DESCRIPTION
Introduce a "par" attribute to enable the use of `\parbox` in LaTeX output, allowing for better handling of line breaks in highlighted text. Update the documentation to reflect this new feature and increment the extension version.