### PR TITLE
feat: update get_brand_color function support light/dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ color:
 
 Using colours from dark/light themes with Quarto CLI >=1.7.20 ([v1.2.0](../../releases/tag/1.2.0)):
 
-- From `_quarto.yml`, `_metadata.yml`, or document front matter:
+- From document front matter:
 
   ```yaml
   brand:
@@ -59,7 +59,7 @@ Using colours from dark/light themes with Quarto CLI >=1.7.20 ([v1.2.0](../../re
         primary: "#abc123"
   ```
 
-- From a `_brand.yml` file
+- From `_quarto.yml` and `_brand.yml` file
 
   ```yaml
   brand:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can also use the shorter syntax ([v1.1.1](../../releases/tag/1.1.1)):
 
 Using colours from `_brand.yml` ([v1.1.0](../../releases/tag/1.1.0)):
 
-```markdown
+```yaml
 color:
   palette:
     red: "#b22222"
@@ -44,6 +44,30 @@ color:
 
 ```markdown
 [Red]{colour="brand-color.red" bg-colour="brand-color.primary"}
+```
+
+Using colours from dark/light themes with Quarto CLI >=1.7.20 ([v1.2.0](../../releases/tag/1.2.0)):
+
+- From `_quarto.yml`, `_metadata.yml`, or document front matter:
+
+  ```yaml
+  brand:
+    dark:
+      color:
+        palette:
+          red: "#b22222"
+        primary: "#abc123"
+  ```
+
+- From a `_brand.yml` file
+
+  ```yaml
+  brand:
+    dark: _brand.yml
+  ```
+
+```markdown
+[Red]{colour="brand-color.red" bg-colour="brand-color.primary" brand="dark"}
 ```
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -46,17 +46,22 @@ color:
 [Red]{colour="brand-color.red" bg-colour="brand-color.primary"}
 ```
 
-Using colours from dark/light themes with Quarto CLI >=1.7.20 ([v1.2.0](../../releases/tag/1.2.0)):
+Using colours from light/dark themes with Quarto CLI >=1.7.28 ([v1.2.0](../../releases/tag/1.2.0)):
 
 - From document front matter:
 
   ```yaml
   brand:
+    light:
+      color:
+        palette:
+          fg: "#ffffff"
+          bg: "#b22222"
     dark:
       color:
         palette:
-          red: "#b22222"
-        primary: "#abc123"
+          fg: "#b22222"
+          bg: "#ffffff"
   ```
 
 - From `_quarto.yml` and `_brand.yml` file
@@ -67,8 +72,12 @@ Using colours from dark/light themes with Quarto CLI >=1.7.20 ([v1.2.0](../../re
   ```
 
 ```markdown
-[Red]{colour="brand-color.red" bg-colour="brand-color.primary" brand="dark"}
+[Light: White/Red | Dark: Red/White]{colour="brand-color.fg" bg-colour="brand-color.bg"}
 ```
+
+> [!NOTE]
+> Only the `html` support light/dark mode switching.
+> The other formats will use the light mode colours if available or the dark mode colours otherwise.
 
 ## Limitations
 

--- a/_extensions/highlight-text/_extension.yml
+++ b/_extensions/highlight-text/_extension.yml
@@ -1,7 +1,7 @@
 title: Highlight Text
 author: Mickaël Canouil
 version: 1.2.0
-quarto-required: ">=1.7.20"
+quarto-required: ">=1.7.28"
 contributes:
   filters:
     - highlight-text.lua

--- a/_extensions/highlight-text/_extension.yml
+++ b/_extensions/highlight-text/_extension.yml
@@ -1,7 +1,7 @@
 title: Highlight Text
 author: Mickaël Canouil
-version: 1.1.3
-quarto-required: ">=1.6.37"
+version: 1.2.0
+quarto-required: ">=1.7.20"
 contributes:
   filters:
     - highlight-text.lua

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -22,7 +22,11 @@
 # SOFTWARE.
 ]]
 
-local function get_brand_color(theme, colour)
+--- Gets a colour value from brand theme or formats it for later use
+--- @param theme string The brand theme to use (light/dark)
+--- @param colour string The colour value or brand colour reference
+--- @return string The processed colour value
+local function get_brand_colour(theme, colour)
   local brand = require('modules/brand/brand')
   if colour and colour:match("^brand%-color.") then
     colour = brand.get_color(theme, colour:gsub("^brand%-color%.", ""))
@@ -34,6 +38,11 @@ local function get_brand_color(theme, colour)
   return colour
 end
 
+--- Applies text and background colour styling for HTML-based outputs
+--- @param span table The span element to modify
+--- @param colour string The text colour to apply
+--- @param bg_colour string The background colour to apply
+--- @return table The modified span with HTML styling
 local function highlight_html(span, colour, bg_colour)
   if span.attributes['style'] == nil then
     span.attributes['style'] = ''
@@ -56,6 +65,12 @@ local function highlight_html(span, colour, bg_colour)
   return span
 end
 
+--- Applies text and background colour styling for LaTeX-based outputs
+--- @param span table The span element to modify
+--- @param colour string The text colour to apply
+--- @param bg_colour string The background colour to apply
+--- @param par boolean Whether to wrap in a paragraph box
+--- @return table The span content with LaTeX markup
 local function highlight_latex(span, colour, bg_colour, par)
   if colour == nil then
     colour_open = ''
@@ -86,6 +101,11 @@ local function highlight_latex(span, colour, bg_colour, par)
   return span.content
 end
 
+--- Applies text and background colour styling for Word documents
+--- @param span table The span element to modify
+--- @param colour string The text colour to apply
+--- @param bg_colour string The background colour to apply
+--- @return table The span content with OpenXML markup for Word
 local function highlight_openxml_docx(span, colour, bg_colour)
   local spec = '<w:r><w:rPr>'
   if bg_colour ~= nil then
@@ -102,6 +122,11 @@ local function highlight_openxml_docx(span, colour, bg_colour)
   return span.content
 end
 
+--- Applies text and background colour styling for PowerPoint presentations
+--- @param span table The span element to modify
+--- @param colour string The text colour to apply
+--- @param bg_colour string The background colour to apply
+--- @return table Raw inline containing OpenXML markup for PowerPoint
 local function highlight_openxml_pptx(span, colour, bg_colour)
   local spec = '<a:r><a:rPr dirty="0">'
   if colour ~= nil then
@@ -123,6 +148,11 @@ local function highlight_openxml_pptx(span, colour, bg_colour)
   return pandoc.RawInline('openxml', spec .. span_content_string .. '</a:t></a:r>')
 end
 
+--- Applies text and background colour styling for Typst output
+--- @param span table The span element to modify
+--- @param colour string The text colour to apply
+--- @param bg_colour string The background colour to apply
+--- @return table The span content with Typst markup
 local function highlight_typst(span, colour, bg_colour)
   if colour == nil then
     colour_open = ''
@@ -152,7 +182,11 @@ local function highlight_typst(span, colour, bg_colour)
   return span.content
 end
 
-function Span(span)
+--- Main filter function that processes span elements and applies highlighting
+--- based on the output format and specified attributes
+--- @param span table The span element from the document
+--- @return table The modified span or span content with appropriate styling
+local function highlight(span)
   local colour = span.attributes['fg']
   if colour == nil then
     colour = span.attributes['colour']
@@ -176,8 +210,8 @@ function Span(span)
 
   if colour == nil and bg_colour == nil then return span end
 
-  colour = get_brand_color(brand, colour)
-  bg_colour = get_brand_color(brand, bg_colour)
+  colour = get_brand_colour(brand, colour)
+  bg_colour = get_brand_colour(brand, bg_colour)
 
   if span.attributes['par'] == nil then
     par = false
@@ -200,3 +234,7 @@ function Span(span)
     return span
   end
 end
+
+return {
+  { Span = highlight },
+}

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -22,10 +22,10 @@
 # SOFTWARE.
 ]]
 
-local function get_brand_color(colour)
+local function get_brand_color(theme, colour)
   local brand = require('modules/brand/brand')
   if colour and colour:match("^brand%-color.") then
-    colour = brand.get_color(colour:gsub("^brand%-color%.", ""))
+    colour = brand.get_color(theme, colour:gsub("^brand%-color%.", ""))
   else
     if FORMAT:match 'typst' and colour  ~= nil then
       colour = 'rgb("' .. colour .. '")'
@@ -169,10 +169,15 @@ function Span(span)
     bg_colour = span.attributes['bg-color']
   end
 
+  local brand = span.attributes['brand']
+  if brand == nil then
+    brand = "light"
+  end
+
   if colour == nil and bg_colour == nil then return span end
 
-  colour = get_brand_color(colour)
-  bg_colour = get_brand_color(bg_colour)
+  colour = get_brand_color(brand, colour)
+  bg_colour = get_brand_color(brand, bg_colour)
 
   if span.attributes['par'] == nil then
     par = false

--- a/_extensions/highlight-text/light-dark.css
+++ b/_extensions/highlight-text/light-dark.css
@@ -1,0 +1,9 @@
+body.quarto-light .quarto-highlight-text-light,
+body.quarto-dark .quarto-highlight-text-dark {
+  display: inline;
+}
+
+body.quarto-light .quarto-highlight-text-dark,
+body.quarto-dark .quarto-highlight-text-light {
+  display: none;
+}

--- a/example.qmd
+++ b/example.qmd
@@ -34,15 +34,17 @@ brand:
   light:
     color:
       palette:
-        blue: "#0000ff"
-        red: "#b22222"
-      primary: "#ffffff"
+        fg: "#ffffff"
+        bg: "#b22222"
+      foreground: "#333333"
+      background: "#fafafa"
   dark:
     color:
       palette:
-        yellow: "#ffff00"
-        green: "#00ff00"
-      primary: "#000000"
+        fg: "#b22222"
+        bg: "#ffffff"
+      foreground: "#fafafa"
+      background: "#333333"
 ---
 
 This is a Quarto extension that allows to highlight text in a document for various format: HTML, LaTeX, Typst, and Docx.
@@ -134,38 +136,13 @@ Then you can use the span syntax markup to highlight text in your document.
 ## `_brand.yml`
 
 ```markdown
-[White text, Red background]{
-  colour="brand-color.primary" bg-colour="brand-color.red"
+[Light: White/Red | Dark: Red/White]{
+  colour="brand-color.fg"
+  bg-colour="brand-color.bg"
 }
 ```
 
-[White text, Red background]{colour="brand-color.primary" bg-colour="brand-color.red"}
-
-```markdown
-[White text, Blue background]{
-  color="brand-color.primary" bg-color="brand-color.blue"
-}
-```
-
-[White text, Blue background]{color="brand-color.primary" bg-color="brand-color.blue"}
-
-## `_brand.yml` light and dark mode
-
-```markdown
-[White text, Red background]{
-  colour="brand-color.primary" bg-colour="brand-color.red" brand="light"
-}
-```
-
-[White text, Red background]{colour="brand-color.primary" bg-colour="brand-color.red" brand="light"}
-
-```markdown
-[White text, Blue background]{
-  color="brand-color.primary" bg-color="brand-color.green" brand="dark"
-}
-```
-
-[White text, Blue background]{color="brand-color.primary" bg-color="brand-color.green" brand="dark"}
+[Light: White/Red | Dark: Red/White]{colour="brand-color.fg" bg-colour="brand-color.bg"}
 
 ## Limitations
 

--- a/example.qmd
+++ b/example.qmd
@@ -31,11 +31,18 @@ execute:
 filters:
   - highlight-text
 brand:
-  color:
-    palette:
-      blue: "#0000ff"
-      red: "#b22222"
-    primary: "#ffffff"
+  light:
+    color:
+      palette:
+        blue: "#0000ff"
+        red: "#b22222"
+      primary: "#ffffff"
+  dark:
+    color:
+      palette:
+        yellow: "#ffff00"
+        green: "#00ff00"
+      primary: "#000000"
 ---
 
 This is a Quarto extension that allows to highlight text in a document for various format: HTML, LaTeX, Typst, and Docx.
@@ -141,6 +148,24 @@ Then you can use the span syntax markup to highlight text in your document.
 ```
 
 [White text, Blue background]{color="brand-color.primary" bg-color="brand-color.blue"}
+
+## `_brand.yml` light and dark mode
+
+```markdown
+[White text, Red background]{
+  colour="brand-color.primary" bg-colour="brand-color.red" brand="light"
+}
+```
+
+[White text, Red background]{colour="brand-color.primary" bg-colour="brand-color.red" brand="light"}
+
+```markdown
+[White text, Blue background]{
+  color="brand-color.primary" bg-color="brand-color.green" brand="dark"
+}
+```
+
+[White text, Blue background]{color="brand-color.primary" bg-color="brand-color.green" brand="dark"}
 
 ## Limitations
 


### PR DESCRIPTION
Add support for brand light/dark from Quarto 1.7