### PR TITLE
feat: use `Lua-UL` with `lualatex` as PDF engine for better highlighting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,6 @@ jobs:
     secrets: inherit
     with:
       version: "${{ github.event.inputs.version }}"
-      formats: "html typst pdf docx revealjs beamer pptx"
+      formats: "html typst pdf-xelatex pdf-lualatex pdf-pdflatex docx revealjs beamer pptx"
       tinytex: true
       quarto: "${{ github.event.inputs.quarto }}"

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ In order to get a slightly better result, you can use the `par=true` attribute t
 [Red]{colour="#b22222" bg-colour="#abc123" par=true}
 ```
 
+Use `pdf-engine: lualatex` in your YAML front matter to use the `luatex` engine and fully alleviate the above issue.
+
 ## Examples
 
 Here is the source code for a minimal example: [`example.qmd`](example.qmd).

--- a/example.qmd
+++ b/example.qmd
@@ -9,8 +9,22 @@ format:
     margin:
       x: 2.5cm
       y: 2.5cm
-  pdf:
-    output-file: highlight-latex
+  pdf-xelatex:
+    output-file: highlight-xelatex
+    papersize: a4
+    margin:
+      x: 2.5cm
+      y: 2.5cm
+  pdf-lualatex:
+    output-file: highlight-lualatex
+    pdf-engine: lualatex
+    papersize: a4
+    margin:
+      x: 2.5cm
+      y: 2.5cm
+  pdf-pdflatex:
+    output-file: highlight-pdflatex
+    pdf-engine: lualatex
     papersize: a4
     margin:
       x: 2.5cm
@@ -144,7 +158,7 @@ Then you can use the span syntax markup to highlight text in your document.
 
 [Light: White/Red | Dark: Red/White]{colour="brand-color.fg" bg-colour="brand-color.bg"}
 
-## Limitations
+## Limitations `xelatex` and `pdflatex`
 
 LaTeX `\colorbox` command does not support wrapping/line breaks in the text to be highlighted.
 This means that the above example will not work well in LaTeX output.
@@ -167,3 +181,5 @@ In order to get a slightly better result, you can use the `par=true` attribute t
   LaTeX `\colorbox` command does not support wrapping/line breaks in the text to be highlighted.
 This means that the above example will not work well in LaTeX output.
 ]{colour="#b22222" bg-colour="#abc123" par=true}
+
+Use `pdf-engine: lualatex` in the YAML front matter to get the best result.

--- a/example.qmd
+++ b/example.qmd
@@ -38,7 +38,19 @@ format:
     aspectratio: 169
   pptx:
     output-file: highlight-pptx
-format-links: true
+format-links:
+  - html
+  - typst
+  - format: pdf-xelatex
+    text: "PDF (XeLaTeX)"
+  - format: pdf-lualatex
+    text: "PDF (LuaLaTeX)"
+  - format: pdf-pdflatex
+    text: "PDF (PDFLaTeX)"
+  - docx
+  - revealjs
+  - beamer
+  - pptx
 embed-resources: true
 execute:
   echo: true


### PR DESCRIPTION
Update the highlighting functionality to leverage `Lua-UL` when the PDF engine is set to `lualatex`, addressing the limitations of the `\colorbox` command that does not support text wrapping. Modify the workflow to include support for `pdf-lualatex` and adjust the example documentation to guide users on achieving better results with the new setup. Fixes #27