### PR TITLE
feat: add ink and paper aliases for text and background colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ You can use abbreviated attribute names ([v1.1.1](../../releases/tag/1.1.1)):
 
 ```markdown
 [Red text]{fg="#b22222"}
+[Red text (ink alias)]{ink="#b22222"}
 [Red background]{bg="#abc123"}
+[Red background (paper alias)]{paper="#abc123"}
 [White on Red]{fg="#ffffff" bg="#b22222"}
+[White on Red (ink/paper aliases)]{ink="#ffffff" paper="#b22222"}
 [Text with solid border]{bc="#0000ff"}
 [Text with dashed border]{bc="#b22222" bs="dashed"}
 [Text with dotted border]{bc="#00aa00" border-style="dotted"}
@@ -62,6 +65,10 @@ For block-level highlighting:
 ```markdown
 ::: {fg="#ffffff" bg="#b22222"}
 Block with white text on red background.
+:::
+
+::: {ink="#ffffff" paper="#b22222"}
+Block with white text on red background (ink/paper aliases).
 :::
 
 ::: {bc="#b22222" bg="#ffffcc"}
@@ -75,8 +82,8 @@ Block with blue dashed border and light grey background.
 
 Supported attributes:
 
-- **Foreground (text) colour**: `fg`, `colour`, or `color`
-- **Background colour**: `bg`, `bg-colour`, or `bg-color`
+- **Foreground (text) colour**: `ink`, `fg`, `colour`, or `color`
+- **Background colour**: `paper`, `bg`, `bg-colour`, or `bg-color`
 - **Border colour**: `bc`, `border-colour`, or `border-color`
 - **Border style**: `bs` or `border-style` (values: `solid`, `dashed`, `dotted`, `double`; defaults to `solid`)
 

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -624,8 +624,8 @@ end
 --- @return string|nil border_colour The border colour
 --- @return string|nil border_style The border style
 local function get_colour_attributes(attributes)
-  local colour = attributes['fg'] or attributes['colour'] or attributes['color']
-  local bg_colour = attributes['bg'] or attributes['bg-colour'] or attributes['bg-color']
+  local colour = attributes['ink'] or attributes['fg'] or attributes['colour'] or attributes['color']
+  local bg_colour = attributes['paper'] or attributes['bg'] or attributes['bg-colour'] or attributes['bg-color']
   local border_colour = attributes['bc'] or attributes['border-colour'] or attributes['border-color']
   local border_style = attributes['bs'] or attributes['border-style']
   return colour, bg_colour, border_colour, border_style

--- a/example.qmd
+++ b/example.qmd
@@ -152,8 +152,8 @@ You can use abbreviated attribute names ([v1.1.1](../../releases/tag/1.1.1)):
 
 Supported attributes:
 
-- **Foreground (text) colour**: `fg`, `colour`, or `color`
-- **Background colour**: `bg`, `bg-colour`, or `bg-color`
+- **Foreground (text) colour**: `ink`, `fg`, `colour`, or `color`
+- **Background colour**: `paper`, `bg`, `bg-colour`, or `bg-color`
 - **Border colour**: `bc`, `border-colour`, or `border-color`
 - **Border style**: `bs` or `border-style` (values: `solid`, `dashed`, `dotted`, `double`; defaults to `solid`)
 
@@ -171,6 +171,12 @@ Supported attributes:
 
 [Blue text]{color="#0000ff"}
 
+```markdown
+[Green text (ink alias)]{ink="#008000"}
+```
+
+[Green text (ink alias)]{ink="#008000"}
+
 ## Background Colour
 
 ```markdown
@@ -184,6 +190,12 @@ Supported attributes:
 ```
 
 [Blue background]{bg-color="#0000ff"}
+
+```markdown
+[Yellow background (paper alias)]{paper="#ffff00"}
+```
+
+[Yellow background (paper alias)]{paper="#ffff00"}
 
 ## Font and Background Colour
 
@@ -202,6 +214,14 @@ Supported attributes:
 ```
 
 [White text, Blue background]{colour="#ffffff" bg-colour="#0000ff"}
+
+```markdown
+[Black text, Orange background (ink/paper aliases)]{
+  ink="#000000" paper="#ffa500"
+}
+```
+
+[Black text, Orange background (ink/paper aliases)]{ink="#000000" paper="#ffa500"}
 
 ## Border Colour
 
@@ -445,6 +465,20 @@ This block has a green dotted border without background.
 :::: {bc="#00aa00" bs="dotted"}
 
 This block has a green dotted border without background.
+
+:::
+
+```markdown
+:::: {ink="#ffffff" paper="#800080"}
+
+This block uses ink/paper aliases with white text on purple background.
+
+:::
+```
+
+:::: {ink="#ffffff" paper="#800080"}
+
+This block uses ink/paper aliases with white text on purple background.
 
 :::
 


### PR DESCRIPTION
Introduce aliases `ink` for foreground colour and `paper` for background colour to enhance readability and flexibility in styling. Update documentation to reflect these changes and provide examples for users.