### PR TITLE
feat: validate colours, add opacity/gradient/var(), warn on PowerPoint borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## 2.3.0 (2026-05-28)
+
+### New Features
+
+- feat: Validate colour values and warn on unrecognised hex/CSS/named values instead of crashing.
+- feat: Support CSS `var(--...)` references for foreground, background, and border colours (HTML only).
+- feat: Add `opacity` attribute for translucent text/background (HTML only).
+- feat: Add `gradient` attribute for block-level gradient fills (HTML only).
+- feat: Warn once per render when PowerPoint discards a border colour.
+
+### Bug Fixes
+
+- fix: Stop crashing when a border colour is not a 6-character hex (named CSS colours and invalid hex no longer raise a runtime error).
+- fix: Strip `ink`/`paper` (and other input aliases) so they no longer leak as `data-*` attributes in HTML output.
+- fix: Synchronise shared modules (`logging.lua`, `colour.lua`) with canonical versions.
+
 ## 2.2.1 (2026-04-15)
 
 ### Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 2.3.0 (2026-05-28)
-
 ### New Features
 
 - feat: Validate colour values and warn on unrecognised hex/CSS/named values instead of crashing.

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Supported attributes:
 - **Background colour**: `paper`, `bg`, `bg-colour`, or `bg-color`.
 - **Border colour**: `bc`, `border-colour`, or `border-color`.
 - **Border style**: `bs` or `border-style` (values: `solid`, `dashed`, `dotted`, `double`; defaults to `solid`).
-- **Opacity** (HTML only): `opacity` accepts a number in `[0, 1]` or a percentage (e.g. `"50%"`). Applied to the background when present, otherwise to the element as a whole.
-- **Gradient fill** (HTML block-level only): `gradient` accepts a full `linear-gradient(...)`/`radial-gradient(...)` value or a comma-separated list of colour stops (becomes a left-to-right linear gradient).
+- **Opacity** (HTML and Typst): `opacity` accepts a number in `[0, 1]` or a percentage (e.g. `"50%"`). Applied to the background when present, otherwise to the element as a whole.
+- **Gradient fill** (HTML and Typst, block-level only): `gradient` accepts a full `linear-gradient(...)`/`radial-gradient(...)` value or a comma-separated list of colour stops (becomes a left-to-right linear gradient). Typst output uses native `gradient.linear`/`gradient.radial`.
 
 Colour values accept hex codes (`#RGB`/`#RRGGBB`), CSS functional notation (`rgb()`, `hsl()`, `hwb()`), CSS named colours, brand colour names, and CSS custom properties (`var(--brand-primary)`).
 CSS `var()` references are only resolved by the browser, so they apply to HTML/RevealJS output only.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a Quarto extension that allows to highlight text in a document for vario
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-highlight-text@2.3.0
+quarto add mcanouil/quarto-highlight-text@2.2.1
 ```
 
 This will install the extension under the `_extensions` subdirectory.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a Quarto extension that allows to highlight text in a document for vario
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-highlight-text@2.2.1
+quarto add mcanouil/quarto-highlight-text@2.3.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -82,10 +82,16 @@ Block with blue dashed border and light grey background.
 
 Supported attributes:
 
-- **Foreground (text) colour**: `ink`, `fg`, `colour`, or `color`
-- **Background colour**: `paper`, `bg`, `bg-colour`, or `bg-color`
-- **Border colour**: `bc`, `border-colour`, or `border-color`
-- **Border style**: `bs` or `border-style` (values: `solid`, `dashed`, `dotted`, `double`; defaults to `solid`)
+- **Foreground (text) colour**: `ink`, `fg`, `colour`, or `color`.
+- **Background colour**: `paper`, `bg`, `bg-colour`, or `bg-color`.
+- **Border colour**: `bc`, `border-colour`, or `border-color`.
+- **Border style**: `bs` or `border-style` (values: `solid`, `dashed`, `dotted`, `double`; defaults to `solid`).
+- **Opacity** (HTML only): `opacity` accepts a number in `[0, 1]` or a percentage (e.g. `"50%"`). Applied to the background when present, otherwise to the element as a whole.
+- **Gradient fill** (HTML block-level only): `gradient` accepts a full `linear-gradient(...)`/`radial-gradient(...)` value or a comma-separated list of colour stops (becomes a left-to-right linear gradient).
+
+Colour values accept hex codes (`#RGB`/`#RRGGBB`), CSS functional notation (`rgb()`, `hsl()`, `hwb()`), CSS named colours, brand colour names, and CSS custom properties (`var(--brand-primary)`).
+CSS `var()` references are only resolved by the browser, so they apply to HTML/RevealJS output only.
+Invalid colour values are skipped with a warning rather than producing malformed output.
 
 ### Using Brand Colours
 
@@ -182,6 +188,7 @@ format:
 Links are not supported in highlighted text in PowerPoint output, *i.e.*, URLs will be rendered using default styles.
 
 Border colour is not supported in PowerPoint output.
+A warning is emitted once per render when a border colour is requested for PowerPoint.
 
 ### Word Output
 

--- a/_extensions/highlight-text/_extension.yml
+++ b/_extensions/highlight-text/_extension.yml
@@ -1,6 +1,6 @@
 title: Highlight Text
 author: Mickaël Canouil
-version: 2.3.0
+version: 2.2.1
 quarto-required: ">=1.7.29"
 contributes:
   filters:

--- a/_extensions/highlight-text/_extension.yml
+++ b/_extensions/highlight-text/_extension.yml
@@ -1,6 +1,6 @@
 title: Highlight Text
 author: Mickaël Canouil
-version: 2.2.1
+version: 2.3.0
 quarto-required: ">=1.7.29"
 contributes:
   filters:

--- a/_extensions/highlight-text/_modules/colour.lua
+++ b/_extensions/highlight-text/_modules/colour.lua
@@ -1,0 +1,369 @@
+--- MC Colour - Colour conversion utilities for Quarto Lua filters and shortcodes
+--- @module "colour"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 1.0.0
+
+local M = {}
+
+-- ============================================================================
+-- CSS NAMED COLOURS
+-- ============================================================================
+
+--- CSS named colours lookup table.
+--- Maps lowercase colour names to uppercase 6-character hex codes.
+--- Contains all 148 standard CSS named colours.
+--- @type table<string, string>
+local CSS_NAMED_COLOURS = {
+  aliceblue = '#F0F8FF',
+  antiquewhite = '#FAEBD7',
+  aqua = '#00FFFF',
+  aquamarine = '#7FFFD4',
+  azure = '#F0FFFF',
+  beige = '#F5F5DC',
+  bisque = '#FFE4C4',
+  black = '#000000',
+  blanchedalmond = '#FFEBCD',
+  blue = '#0000FF',
+  blueviolet = '#8A2BE2',
+  brown = '#A52A2A',
+  burlywood = '#DEB887',
+  cadetblue = '#5F9EA0',
+  chartreuse = '#7FFF00',
+  chocolate = '#D2691E',
+  coral = '#FF7F50',
+  cornflowerblue = '#6495ED',
+  cornsilk = '#FFF8DC',
+  crimson = '#DC143C',
+  cyan = '#00FFFF',
+  darkblue = '#00008B',
+  darkcyan = '#008B8B',
+  darkgoldenrod = '#B8860B',
+  darkgray = '#A9A9A9',
+  darkgreen = '#006400',
+  darkgrey = '#A9A9A9',
+  darkkhaki = '#BDB76B',
+  darkmagenta = '#8B008B',
+  darkolivegreen = '#556B2F',
+  darkorange = '#FF8C00',
+  darkorchid = '#9932CC',
+  darkred = '#8B0000',
+  darksalmon = '#E9967A',
+  darkseagreen = '#8FBC8F',
+  darkslateblue = '#483D8B',
+  darkslategray = '#2F4F4F',
+  darkslategrey = '#2F4F4F',
+  darkturquoise = '#00CED1',
+  darkviolet = '#9400D3',
+  deeppink = '#FF1493',
+  deepskyblue = '#00BFFF',
+  dimgray = '#696969',
+  dimgrey = '#696969',
+  dodgerblue = '#1E90FF',
+  firebrick = '#B22222',
+  floralwhite = '#FFFAF0',
+  forestgreen = '#228B22',
+  fuchsia = '#FF00FF',
+  gainsboro = '#DCDCDC',
+  ghostwhite = '#F8F8FF',
+  gold = '#FFD700',
+  goldenrod = '#DAA520',
+  gray = '#808080',
+  green = '#008000',
+  greenyellow = '#ADFF2F',
+  grey = '#808080',
+  honeydew = '#F0FFF0',
+  hotpink = '#FF69B4',
+  indianred = '#CD5C5C',
+  indigo = '#4B0082',
+  ivory = '#FFFFF0',
+  khaki = '#F0E68C',
+  lavender = '#E6E6FA',
+  lavenderblush = '#FFF0F5',
+  lawngreen = '#7CFC00',
+  lemonchiffon = '#FFFACD',
+  lightblue = '#ADD8E6',
+  lightcoral = '#F08080',
+  lightcyan = '#E0FFFF',
+  lightgoldenrodyellow = '#FAFAD2',
+  lightgray = '#D3D3D3',
+  lightgreen = '#90EE90',
+  lightgrey = '#D3D3D3',
+  lightpink = '#FFB6C1',
+  lightsalmon = '#FFA07A',
+  lightseagreen = '#20B2AA',
+  lightskyblue = '#87CEFA',
+  lightslategray = '#778899',
+  lightslategrey = '#778899',
+  lightsteelblue = '#B0C4DE',
+  lightyellow = '#FFFFE0',
+  lime = '#00FF00',
+  limegreen = '#32CD32',
+  linen = '#FAF0E6',
+  magenta = '#FF00FF',
+  maroon = '#800000',
+  mediumaquamarine = '#66CDAA',
+  mediumblue = '#0000CD',
+  mediumorchid = '#BA55D3',
+  mediumpurple = '#9370DB',
+  mediumseagreen = '#3CB371',
+  mediumslateblue = '#7B68EE',
+  mediumspringgreen = '#00FA9A',
+  mediumturquoise = '#48D1CC',
+  mediumvioletred = '#C71585',
+  midnightblue = '#191970',
+  mintcream = '#F5FFFA',
+  mistyrose = '#FFE4E1',
+  moccasin = '#FFE4B5',
+  navajowhite = '#FFDEAD',
+  navy = '#000080',
+  oldlace = '#FDF5E6',
+  olive = '#808000',
+  olivedrab = '#6B8E23',
+  orange = '#FFA500',
+  orangered = '#FF4500',
+  orchid = '#DA70D6',
+  palegoldenrod = '#EEE8AA',
+  palegreen = '#98FB98',
+  paleturquoise = '#AFEEEE',
+  palevioletred = '#DB7093',
+  papayawhip = '#FFEFD5',
+  peachpuff = '#FFDAB9',
+  peru = '#CD853F',
+  pink = '#FFC0CB',
+  plum = '#DDA0DD',
+  powderblue = '#B0E0E6',
+  purple = '#800080',
+  rebeccapurple = '#663399',
+  red = '#FF0000',
+  rosybrown = '#BC8F8F',
+  royalblue = '#4169E1',
+  saddlebrown = '#8B4513',
+  salmon = '#FA8072',
+  sandybrown = '#F4A460',
+  seagreen = '#2E8B57',
+  seashell = '#FFF5EE',
+  sienna = '#A0522D',
+  silver = '#C0C0C0',
+  skyblue = '#87CEEB',
+  slateblue = '#6A5ACD',
+  slategray = '#708090',
+  slategrey = '#708090',
+  snow = '#FFFAFA',
+  springgreen = '#00FF7F',
+  steelblue = '#4682B4',
+  tan = '#D2B48C',
+  teal = '#008080',
+  thistle = '#D8BFD8',
+  tomato = '#FF6347',
+  turquoise = '#40E0D0',
+  violet = '#EE82EE',
+  wheat = '#F5DEB3',
+  white = '#FFFFFF',
+  whitesmoke = '#F5F5F5',
+  yellow = '#FFFF00',
+  yellowgreen = '#9ACD32'
+}
+
+--- Check if a value is a CSS named colour.
+--- Performs case-insensitive matching against the 148 standard CSS named colours.
+--- @param value string|nil The colour value to check
+--- @return boolean True if the value is a recognised CSS named colour
+--- @usage local result = M.is_named_colour('rebeccapurple') -- returns true
+function M.is_named_colour(value)
+  if not value then return false end
+  return CSS_NAMED_COLOURS[value:lower()] ~= nil
+end
+
+-- ============================================================================
+-- COLOUR CONVERSION UTILITIES
+-- ============================================================================
+
+--- Expand 3-character hex colour to 6-character format.
+--- @param hex string Hex colour code (either #123 or #123456 format)
+--- @return string 6-character hex colour code (e.g., #123 becomes #112233)
+function M.expand_hex_colour(hex)
+  if string.len(hex) == 4 then
+    return (string.gsub(hex, '#(%x)(%x)(%x)', '#%1%1%2%2%3%3'))
+  end
+  return hex
+end
+
+--- Convert RGB colour notation to HTML hex format.
+--- @param rgb string RGB colour string in format "rgb(r, g, b)"
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.RGB_to_HTML(rgb)
+  local r, g, b = rgb:match('rgb%((%d+)%s*,%s*(%d+)%s*,%s*(%d+)%s*%)')
+  r = tonumber(r)
+  g = tonumber(g)
+  b = tonumber(b)
+  return string.upper(string.format('#%02x%02x%02x', r, g, b))
+end
+
+--- Convert RGB percentage notation to HTML hex format.
+--- @param rgb string RGB colour string in format "rgb(r%, g%, b%)"
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.RGBPercent_to_HTML(rgb)
+  local r, g, b = rgb:match('rgb%((%d+)%s*%%%s*,%s*(%d+)%s*%%%s*,%s*(%d+)%s*%%%s*%)')
+  r = math.floor(tonumber(r) * 255 / 100 + 0.5)
+  g = math.floor(tonumber(g) * 255 / 100 + 0.5)
+  b = math.floor(tonumber(b) * 255 / 100 + 0.5)
+  return string.upper(string.format('#%02x%02x%02x', r, g, b))
+end
+
+--- Helper function to convert hue to RGB component.
+--- @param p number
+--- @param q number
+--- @param t number
+--- @return number RGB component value
+function M.hue_to_rgb(p, q, t)
+  if t < 0 then t = t + 1 end
+  if t > 1 then t = t - 1 end
+  if t < 1 / 6 then return p + (q - p) * 6 * t end
+  if t < 1 / 2 then return q end
+  if t < 2 / 3 then return p + (q - p) * (2 / 3 - t) * 6 end
+  return p
+end
+
+--- Convert HSL colour notation to HTML hex format.
+--- @param hsl string HSL colour string in format "hsl(h, s%, l%)"
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.HSL_to_HTML(hsl)
+  local h, s, l = hsl:match('hsl%((%d+)%s*,%s*(%d+)%%%s*,%s*(%d+)%%%s*%)')
+  h = tonumber(h) / 360
+  s = tonumber(s) / 100
+  l = tonumber(l) / 100
+
+  local r, g, b
+  if s == 0 then
+    r, g, b = l, l, l
+  else
+    local q = l < 0.5 and l * (1 + s) or l + s - l * s
+    local p = 2 * l - q
+    r = M.hue_to_rgb(p, q, h + 1 / 3)
+    g = M.hue_to_rgb(p, q, h)
+    b = M.hue_to_rgb(p, q, h - 1 / 3)
+  end
+
+  r = math.floor(r * 255 + 0.5)
+  g = math.floor(g * 255 + 0.5)
+  b = math.floor(b * 255 + 0.5)
+
+  return string.upper(string.format('#%02x%02x%02x', r, g, b))
+end
+
+--- Convert HWB colour notation to HTML hex format.
+--- @param hwb string HWB colour string in format "hwb(h w% b%)"
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.HWB_to_HTML(hwb)
+  local h, w, b = hwb:match('hwb%((%d+)%s+(%d+)%%%s+(%d+)%%%s*%)')
+  h = tonumber(h)
+  w = tonumber(w) / 100
+  b = tonumber(b) / 100
+
+  local sum = w + b
+  if sum > 1 then
+    w = w / sum
+    b = b / sum
+  end
+
+  h = h / 360
+
+  local r, g, b_colour
+  local q = 1
+  local p = 0
+  r = M.hue_to_rgb(p, q, h + 1 / 3)
+  g = M.hue_to_rgb(p, q, h)
+  b_colour = M.hue_to_rgb(p, q, h - 1 / 3)
+
+  r = r * (1 - w - b) + w
+  g = g * (1 - w - b) + w
+  b_colour = b_colour * (1 - w - b) + w
+
+  r = math.floor(r * 255 + 0.5)
+  g = math.floor(g * 255 + 0.5)
+  b_colour = math.floor(b_colour * 255 + 0.5)
+
+  return string.upper(string.format('#%02x%02x%02x', r, g, b_colour))
+end
+
+--- Convert a CSS named colour to HTML hex format.
+--- @param name string CSS colour name (case-insensitive)
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.named_to_HTML(name)
+  local hex = CSS_NAMED_COLOURS[name:lower()]
+  if not hex then
+    error('Unknown CSS named colour: ' .. tostring(name))
+  end
+  return hex
+end
+
+--- Convert a colour code to HTML format based on its format type.
+--- @param code string The colour code to convert
+--- @param format string The colour format (e.g., "hwb", "hsl", "rgb", "rgb_percent", "hex", "named")
+--- @return string HTML hex colour code
+function M.to_html(code, format)
+  local converters = {
+    hwb = M.HWB_to_HTML,
+    hsl = M.HSL_to_HTML,
+    rgb = M.RGB_to_HTML,
+    rgb_percent = M.RGBPercent_to_HTML,
+    hex = M.expand_hex_colour,
+    hex3 = M.expand_hex_colour,
+    hex6 = M.expand_hex_colour,
+    named = M.named_to_HTML
+  }
+
+  local converter = converters[format]
+  if converter then
+    return converter(code)
+  else
+    error('Unsupported colour format: ' .. format)
+  end
+end
+
+-- ============================================================================
+-- COLOUR ATTRIBUTE UTILITIES
+-- ============================================================================
+
+--- Get colour value from attributes table, accepting both British and American spellings.
+--- Checks for 'colour' first (British, primary), then falls back to 'color' (American).
+--- @param attrs table Attributes table (kwargs or element.attributes)
+--- @param default string|nil Default value if neither spelling is found
+--- @return string|nil Colour value or default
+--- @usage local colour = M.get_colour(kwargs, 'info')
+function M.get_colour(attrs, default)
+  if attrs == nil then
+    return default
+  end
+  local value = attrs.colour or attrs.color
+  if value == nil then
+    return default
+  end
+  local str_value = pandoc.utils.stringify(value)
+  if str_value == '' then
+    return default
+  end
+  return str_value
+end
+
+--- Check if a colour value is a custom colour (hex, rgb, hsl, hwb, etc.).
+--- Used to determine whether to apply a semantic class or inline style.
+--- Named CSS colours are not custom colours; they are standard/semantic values.
+--- @param colour string|nil The colour value to check
+--- @return boolean True if it's a custom colour value
+--- @usage local is_custom = M.is_custom_colour('#ff6600') -- returns true
+--- @usage local is_custom = M.is_custom_colour('red') -- returns false
+function M.is_custom_colour(colour)
+  if not colour then return false end
+  if M.is_named_colour(colour) then return false end
+  local lower = colour:lower()
+  return lower:match('^#') or lower:match('^rgb') or lower:match('^hsl') or lower:match('^hwb')
+end
+
+-- ============================================================================
+-- MODULE EXPORT
+-- ============================================================================
+
+return M

--- a/_extensions/highlight-text/_schema.yml
+++ b/_extensions/highlight-text/_schema.yml
@@ -2,7 +2,7 @@
 # Provides configuration validation and IDE support for attributes
 # on Span and Div elements with the highlight class.
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 attributes:
   _any:

--- a/_extensions/highlight-text/_schema.yml
+++ b/_extensions/highlight-text/_schema.yml
@@ -36,7 +36,7 @@ attributes:
       description: "Enable paragraph box wrapping for LaTeX output."
     opacity:
       type: string
-      description: "Opacity in [0, 1] or as a percentage (e.g. \"50%\"). HTML only; applied to the background when present, otherwise to the element."
+      description: "Opacity in [0, 1] or as a percentage (e.g. \"50%\"). HTML and Typst; applied to the background when present, otherwise to the element/text."
     gradient:
       type: string
-      description: "Block-level gradient fill. Accepts a full `linear-gradient(...)`/`radial-gradient(...)` value, or a comma-separated list of colour stops (becomes a left-to-right linear gradient). HTML only."
+      description: "Block-level gradient fill. Accepts a full `linear-gradient(...)`/`radial-gradient(...)` value, or a comma-separated list of colour stops (becomes a left-to-right linear gradient). HTML and Typst (block-level only)."

--- a/_extensions/highlight-text/_schema.yml
+++ b/_extensions/highlight-text/_schema.yml
@@ -9,19 +9,19 @@ attributes:
     colour:
       type: string
       aliases: [color, ink, fg]
-      description: "Text (foreground) colour. Accepts CSS colour values or brand colour names."
+      description: "Text (foreground) colour. Accepts CSS colour values, brand colour names, or CSS `var(...)` references (HTML only)."
       completion:
         type: color
     bg-colour:
       type: string
       aliases: [bg-color, bg, paper]
-      description: "Background colour. Accepts CSS colour values or brand colour names."
+      description: "Background colour. Accepts CSS colour values, brand colour names, or CSS `var(...)` references (HTML only)."
       completion:
         type: color
     border-colour:
       type: string
       aliases: [border-color, bc]
-      description: "Border colour. Accepts CSS colour values or brand colour names."
+      description: "Border colour. Accepts CSS colour values, brand colour names, or CSS `var(...)` references (HTML only)."
       completion:
         type: color
     border-style:
@@ -34,3 +34,9 @@ attributes:
       type: boolean
       default: false
       description: "Enable paragraph box wrapping for LaTeX output."
+    opacity:
+      type: string
+      description: "Opacity in [0, 1] or as a percentage (e.g. \"50%\"). HTML only; applied to the background when present, otherwise to the element."
+    gradient:
+      type: string
+      description: "Block-level gradient fill. Accepts a full `linear-gradient(...)`/`radial-gradient(...)` value, or a comma-separated list of colour stops (becomes a left-to-right linear gradient). HTML only."

--- a/_extensions/highlight-text/_snippets.json
+++ b/_extensions/highlight-text/_snippets.json
@@ -18,5 +18,15 @@
 		"prefix": "highlight-div",
 		"body": ["::: {fg=\"${1:#ffffff}\" bg=\"${2:#b22222}\"}", "${3:Block content.}", ":::"],
 		"description": "Wrap a block in foreground/background colour"
+	},
+	"Highlight with opacity": {
+		"prefix": "highlight-opacity",
+		"body": "[${1:text}]{bg=\"${2:#b22222}\" opacity=\"${3:0.5}\"}",
+		"description": "Highlight text with a translucent background (HTML only)"
+	},
+	"Block with gradient": {
+		"prefix": "highlight-gradient",
+		"body": ["::: {gradient=\"${1:#ff7e5f, #feb47b}\"}", "${2:Block content.}", ":::"],
+		"description": "Wrap a block in a CSS gradient fill (HTML only)"
 	}
 }

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -151,6 +151,17 @@ local function apply_opacity_css(colour, opacity)
   return string.format('rgba(%d, %d, %d, %s)', r, g, b, tostring(opacity))
 end
 
+--- Apply an opacity to a Typst colour expression via `.transparentize()`.
+--- An opacity of `o` maps to `transparentize((1 - o) * 100%)` so that `o = 0.5`
+--- yields `transparentize(50%)`.
+--- @param colour string A Typst colour expression (e.g. `rgb("#...")`)
+--- @param opacity number A value in [0, 1]
+--- @return string The colour expression with `.transparentize(P%)` appended
+local function apply_opacity_typst(colour, opacity)
+  local pct = (1 - opacity) * 100
+  return colour .. '.transparentize(' .. string.format('%g', pct) .. '%)'
+end
+
 --- Parse and validate an opacity attribute value.
 --- Accepts a number in [0, 1] or a percentage string (e.g. "50%").
 --- Out-of-range or malformed values emit a warning and return nil.
@@ -193,6 +204,123 @@ local function parse_gradient(value)
     return str
   end
   return 'linear-gradient(to right, ' .. str .. ')'
+end
+
+--- Split a string on top-level commas, ignoring commas nested in parentheses.
+--- Keeps commas inside `rgb(0, 0, 0)`/`hsl(...)` from splitting colour stops.
+--- @param str string The string to split
+--- @return table A list of trimmed, non-empty segments
+local function split_top_level_commas(str)
+  local parts = {}
+  local depth = 0
+  local current = ''
+  for i = 1, #str do
+    local ch = str:sub(i, i)
+    if ch == '(' then
+      depth = depth + 1
+      current = current .. ch
+    elseif ch == ')' then
+      depth = depth - 1
+      current = current .. ch
+    elseif ch == ',' and depth == 0 then
+      parts[#parts + 1] = current:match('^%s*(.-)%s*$')
+      current = ''
+    else
+      current = current .. ch
+    end
+  end
+  if current:match('%S') then
+    parts[#parts + 1] = current:match('^%s*(.-)%s*$')
+  end
+  return parts
+end
+
+--- Parse a single CSS colour stop into a Typst-ready table.
+--- Separates an optional trailing position (e.g. `0%`, `2em`) from the colour and
+--- wraps the colour as `rgb("...")` (matching the Typst branch of `get_brand_colour`).
+--- @param stop string A single colour stop (e.g. `#00b09b 0%`)
+--- @return table A table `{ colour = 'rgb("...")', position = <string|nil> }`
+local function parse_stop(stop)
+  local colour, position = stop:match('^(.-)%s+([%-%d%.]+%%?[a-z]*)$')
+  if colour == nil then
+    colour = stop
+  end
+  return {
+    colour = 'rgb("' .. colour:match('^%s*(.-)%s*$') .. '")',
+    position = position
+  }
+end
+
+--- Parse a `gradient` attribute into a structured representation for Typst rendering.
+--- Accepts the same inputs as `parse_gradient` (full `linear-gradient(...)`/
+--- `radial-gradient(...)` or a comma-separated colour-stop shorthand).
+--- @param value string|nil The raw attribute value
+--- @return table|nil A table
+---   `{ kind = 'linear'|'radial', dir = <'ltr'|'rtl'|'ttb'|'btt'|nil>, angle = <number|nil>,
+---      stops = { { colour = ..., position = ... }, ... } }`, or nil
+local function parse_gradient_typst(value)
+  if value == nil then return nil end
+  local str = pandoc.utils.stringify(value)
+  if str == '' then return nil end
+
+  local kind, dir, angle = 'linear', nil, nil
+  local inner
+
+  local linear = str:match('^%s*linear%-gradient%s*%((.*)%)%s*$')
+  local radial = str:match('^%s*radial%-gradient%s*%((.*)%)%s*$')
+
+  if radial ~= nil then
+    kind = 'radial'
+    inner = radial
+  elseif linear ~= nil then
+    local segments = split_top_level_commas(linear)
+    local first = segments[1] or ''
+    local degrees = first:match('^([%-%d%.]+)deg$')
+    if first:match('^to%s+') then
+      local keyword = first:gsub('^to%s+', '')
+      local directions = { right = 'ltr', left = 'rtl', bottom = 'ttb', top = 'btt' }
+      dir = directions[keyword]
+      table.remove(segments, 1)
+    elseif degrees ~= nil then
+      angle = (tonumber(degrees) - 90) % 360
+      table.remove(segments, 1)
+    end
+    inner = table.concat(segments, ', ')
+  else
+    dir = 'ltr'
+    inner = str
+  end
+
+  local stops = {}
+  for _, segment in ipairs(split_top_level_commas(inner)) do
+    stops[#stops + 1] = parse_stop(segment)
+  end
+  if #stops == 0 then return nil end
+
+  return { kind = kind, dir = dir, angle = angle, stops = stops }
+end
+
+--- Render a structured gradient (from `parse_gradient_typst`) as Typst markup.
+--- @param gradient table The structured gradient
+--- @return string A Typst `gradient.linear(...)`/`gradient.radial(...)` expression
+local function gradient_to_typst(gradient)
+  local args = {}
+  if gradient.kind == 'linear' then
+    if gradient.angle ~= nil then
+      args[#args + 1] = 'angle: ' .. string.format('%g', gradient.angle) .. 'deg'
+    elseif gradient.dir ~= nil then
+      args[#args + 1] = 'dir: ' .. gradient.dir
+    end
+  end
+  for _, stop in ipairs(gradient.stops) do
+    if stop.position ~= nil then
+      args[#args + 1] = '(' .. stop.colour .. ', ' .. stop.position .. ')'
+    else
+      args[#args + 1] = stop.colour
+    end
+  end
+  local fn = gradient.kind == 'radial' and 'gradient.radial' or 'gradient.linear'
+  return fn .. '(' .. table.concat(args, ', ') .. ')'
 end
 
 --- Strip every input-alias attribute consumed by the filter so they do not leak to output.
@@ -644,11 +772,20 @@ end
 --- @param bg_colour string|nil The background colour to apply
 --- @param border_colour string|nil The border colour to apply
 --- @param border_style string|nil The border style to apply
+--- @param opacity number|nil The opacity in [0, 1] (applied to background if present, else foreground)
 --- @return table The span content with Typst markup
-local function highlight_typst(span, colour, bg_colour, border_colour, border_style)
+local function highlight_typst(span, colour, bg_colour, border_colour, border_style, opacity)
+  if opacity ~= nil and bg_colour ~= nil then
+    bg_colour = apply_opacity_typst(bg_colour, opacity)
+  end
+
   local colour_open, colour_close = '', ''
   if colour ~= nil then
-    colour_open = '#text(' .. colour .. ')['
+    local text_colour = colour
+    if opacity ~= nil and bg_colour == nil then
+      text_colour = apply_opacity_typst(colour, opacity)
+    end
+    colour_open = '#text(' .. text_colour .. ')['
     colour_close = ']'
   end
 
@@ -700,11 +837,28 @@ end
 --- @param bg_colour string|nil The background colour to apply
 --- @param border_colour string|nil The border colour to apply
 --- @param border_style string|nil The border style to apply
+--- @param opacity number|nil The opacity in [0, 1] (ignored when a gradient is present)
+--- @param gradient table|nil A structured gradient from `parse_gradient_typst`
 --- @return table The div content with Typst markup
-local function highlight_typst_block(div, colour, bg_colour, border_colour, border_style)
+local function highlight_typst_block(div, colour, bg_colour, border_colour, border_style, opacity, gradient)
+  -- Resolve the block fill: a gradient takes precedence over a background colour.
+  local fill = nil
+  if gradient ~= nil then
+    fill = gradient_to_typst(gradient)
+  elseif bg_colour ~= nil then
+    fill = bg_colour
+    if opacity ~= nil then
+      fill = apply_opacity_typst(fill, opacity)
+    end
+  end
+
   local colour_open, colour_close = '', ''
   if colour ~= nil then
-    colour_open = '#text(' .. colour .. ')['
+    local text_colour = colour
+    if opacity ~= nil and gradient == nil and bg_colour == nil then
+      text_colour = apply_opacity_typst(colour, opacity)
+    end
+    colour_open = '#text(' .. text_colour .. ')['
     colour_close = ']'
   end
 
@@ -724,18 +878,18 @@ local function highlight_typst_block(div, colour, bg_colour, border_colour, bord
     end
   end
 
-  if border_colour ~= nil and bg_colour ~= nil then
+  if border_colour ~= nil and fill ~= nil then
     local stroke_spec = build_stroke(border_colour, border_style)
     border_open = '#block(stroke: ' ..
-        stroke_spec .. ', fill: ' .. bg_colour .. ', inset: (x: 0.5em, y: 0.9em), radius: 0.2em)['
+        stroke_spec .. ', fill: ' .. fill .. ', inset: (x: 0.5em, y: 0.9em), radius: 0.2em)['
     border_close = ']'
   elseif border_colour ~= nil then
     local stroke_spec = build_stroke(border_colour, border_style)
     border_open = '#block(stroke: ' .. stroke_spec ..
         ', inset: (x: 0.5em, y: 0.9em), radius: 0.2em)['
     border_close = ']'
-  elseif bg_colour ~= nil then
-    bg_colour_open = '#block(fill: ' .. bg_colour .. ', inset: 0.5em, radius: 0.2em)['
+  elseif fill ~= nil then
+    bg_colour_open = '#block(fill: ' .. fill .. ', inset: 0.5em, radius: 0.2em)['
     bg_colour_close = ']'
   end
 
@@ -846,7 +1000,7 @@ local function highlight(span)
   elseif quarto.doc.is_format('pptx') then
     return highlight_openxml_pptx(span, colour, bg_colour, border_colour)
   elseif quarto.doc.is_format('typst') then
-    return highlight_typst(span, colour, bg_colour, border_colour, border_style)
+    return highlight_typst(span, colour, bg_colour, border_colour, border_style, opacity)
   else
     return span
   end
@@ -860,6 +1014,7 @@ local function highlight_block(div)
   local colour, bg_colour, border_colour, border_style = get_colour_attributes(div.attributes)
   local opacity = parse_opacity(div.attributes['opacity'])
   local gradient = parse_gradient(div.attributes['gradient'])
+  local gradient_typst = parse_gradient_typst(div.attributes['gradient'])
   local highlight_settings = process_highlight_settings(colour, bg_colour, border_colour, border_style, opacity, gradient)
 
   if highlight_settings == nil then
@@ -875,10 +1030,10 @@ local function highlight_block(div)
     return div
   end
 
-  if gradient ~= nil and not (quarto.doc.is_format('html') or quarto.doc.is_format('revealjs')) then
+  if gradient ~= nil and not (quarto.doc.is_format('html') or quarto.doc.is_format('revealjs') or quarto.doc.is_format('typst')) then
     log.log_warning(
       EXTENSION_NAME,
-      'The "gradient" attribute is only supported in HTML/RevealJS output; ignoring for format "' .. FORMAT .. '".'
+      'The "gradient" attribute is only supported in HTML/RevealJS/Typst output; ignoring for format "' .. FORMAT .. '".'
     )
   end
 
@@ -893,7 +1048,7 @@ local function highlight_block(div)
   elseif quarto.doc.is_format('pptx') then
     return highlight_openxml_pptx_block(div, colour, bg_colour, border_colour)
   elseif quarto.doc.is_format('typst') then
-    return highlight_typst_block(div, colour, bg_colour, border_colour, border_style)
+    return highlight_typst_block(div, colour, bg_colour, border_colour, border_style, opacity, gradient_typst)
   else
     return div
   end

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -8,50 +8,184 @@ local EXTENSION_NAME = "highlight-text"
 
 --- Load modules
 local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
+local colour_utils = require(quarto.utils.resolve_path('_modules/colour.lua'):gsub('%.lua$', ''))
 
 --- Flag to track if deprecation warning has been shown
 --- @type boolean
 local deprecation_warning_shown = false
 
---- Gets a colour value from brand theme or formats it for later use
---- @param theme string The brand theme to use (light/dark)
---- @param colour string|nil The colour value or brand colour reference
---- @return string|nil The processed colour value
-local function get_brand_colour(theme, colour)
-  local brand = require('modules/brand/brand')
+--- Flag to track if the PowerPoint border-discard warning has been shown
+--- @type boolean
+local pptx_border_warning_shown = false
 
-
-  if colour then
-    local brand_colour_key = colour
-
-    -- Check for deprecated "brand-color." prefix
-    brand_colour_key = colour:gsub('^brand%-color%.', '')
-    if not deprecation_warning_shown then
-      if colour:match("^brand%-color%.") then
-        log.log_warning(
-          EXTENSION_NAME,
-          'Using "brand-color." prefix is deprecated.' ..
-          ' Please use the colour name directly (e.g., "' .. brand_colour_key .. '" instead of "' .. colour .. '").'
-        )
-        deprecation_warning_shown = true
-      end
-    end
-
-    local brand_colour = brand.get_color(theme, brand_colour_key)
-    if brand_colour ~= nil then
-      colour = brand_colour
-    else
-      if FORMAT:match 'typst' and colour ~= nil then
-        colour = 'rgb("' .. colour .. '")'
-      end
-    end
-  end
-  return colour
+--- Check whether a string looks like a CSS custom property reference (e.g. "var(--brand-primary)").
+--- @param value string|nil The value to inspect
+--- @return boolean True when the value starts with "var(" after trimming whitespace
+local function is_css_var(value)
+  if type(value) ~= 'string' then return false end
+  return value:match('^%s*var%s*%(') ~= nil
 end
 
---- Applies HTML styling to an element
+--- Resolve a colour reference to a concrete colour value.
+--- Brand colour names are resolved via the Quarto brand API.
+--- CSS `var()` references are preserved for HTML output.
+--- Hex/CSS colour values are validated.
+--- Invalid values trigger a warning and return nil so callers can skip the styling.
+--- @param theme string The brand theme to use (light/dark)
+--- @param colour string|nil The colour value or brand colour reference
+--- @param attribute string Human-readable attribute label used in warnings
+--- @return string|nil The processed colour value or nil when invalid
+local function get_brand_colour(theme, colour, attribute)
+  local brand = require('modules/brand/brand')
+
+  if colour == nil then
+    return nil
+  end
+
+  if is_css_var(colour) then
+    if FORMAT == 'html' or FORMAT:match('revealjs') then
+      return colour
+    end
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring CSS `var()` ' .. attribute .. ' "' .. colour .. '" for format "' .. FORMAT .. '": only supported in HTML/RevealJS output.'
+    )
+    return nil
+  end
+
+  local brand_colour_key = colour:gsub('^brand%-color%.', '')
+  if colour:match('^brand%-color%.') and not deprecation_warning_shown then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Using "brand-color." prefix is deprecated.' ..
+      ' Please use the colour name directly (e.g., "' .. brand_colour_key .. '" instead of "' .. colour .. '").'
+    )
+    deprecation_warning_shown = true
+  end
+
+  local brand_colour = brand.get_color(theme, brand_colour_key)
+  if brand_colour ~= nil then
+    return brand_colour
+  end
+
+  if FORMAT:match('typst') then
+    return 'rgb("' .. colour .. '")'
+  end
+
+  if colour:match('^#') or colour:match('^rgb') or colour:match('^hsl') or colour:match('^hwb')
+      or colour_utils.is_named_colour(colour) then
+    return colour
+  end
+
+  log.log_warning(
+    EXTENSION_NAME,
+    'Ignoring invalid ' .. attribute .. ' value "' .. colour .. '": ' ..
+    'expected a hex (#RGB/#RRGGBB), CSS function (rgb/hsl/hwb), named colour, ' ..
+    'CSS var(), or brand colour name.'
+  )
+  return nil
+end
+
+--- Convert a colour reference to a 6-character hex (without leading "#") for LaTeX/Word/PowerPoint.
+--- Brand-resolved values are already concrete; this normalises hex (3 or 6 digits) and named colours.
+--- Returns nil for values that cannot be expressed as a hex code (rgb(), hsl(), CSS var(), Typst rgb()).
+--- @param colour string|nil The colour value
+--- @return string|nil A 6-character hex string without "#", or nil when not expressible as hex
+local function to_hex6(colour)
+  if colour == nil then return nil end
+  if colour_utils.is_named_colour(colour) then
+    return colour_utils.named_to_HTML(colour):gsub('^#', '')
+  end
+  if colour:match('^#%x%x%x%x%x%x$') then
+    return colour:sub(2)
+  end
+  if colour:match('^#%x%x%x$') then
+    return colour_utils.expand_hex_colour(colour):gsub('^#', '')
+  end
+  return nil
+end
+
+--- Apply opacity to a CSS-style colour value when the colour is a hex code.
+--- Returns the original value unchanged when conversion is not possible (e.g. `var()`, rgb()).
+--- For hex inputs, returns an `rgba()` string.
+--- @param colour string|nil The colour value
+--- @param opacity number A value in [0, 1]
+--- @return string|nil The colour with opacity applied where possible, or the original value
+local function apply_opacity_css(colour, opacity)
+  if colour == nil then return nil end
+  local hex = to_hex6(colour)
+  if hex == nil then
+    return colour
+  end
+  local r = tonumber(hex:sub(1, 2), 16)
+  local g = tonumber(hex:sub(3, 4), 16)
+  local b = tonumber(hex:sub(5, 6), 16)
+  return string.format('rgba(%d, %d, %d, %s)', r, g, b, tostring(opacity))
+end
+
+--- Parse and validate an opacity attribute value.
+--- Accepts a number in [0, 1] or a percentage string (e.g. "50%").
+--- Out-of-range or malformed values emit a warning and return nil.
+--- @param value string|number|nil The raw attribute value
+--- @return number|nil A number in [0, 1], or nil when the value is absent or invalid
+local function parse_opacity(value)
+  if value == nil then return nil end
+  local str = pandoc.utils.stringify(value)
+  if str == '' then return nil end
+  local percent = str:match('^%s*([%-%d%.]+)%s*%%%s*$')
+  local number = percent and tonumber(percent) / 100 or tonumber(str)
+  if number == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring invalid opacity value "' .. str .. '": expected a number in [0, 1] or a percentage.'
+    )
+    return nil
+  end
+  if number < 0 or number > 1 then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring out-of-range opacity value "' .. str .. '": must be in [0, 1].'
+    )
+    return nil
+  end
+  return number
+end
+
+--- Build a CSS gradient value from a `gradient` attribute string.
+--- Accepts either a full `linear-gradient(...)`/`radial-gradient(...)` value (passed through),
+--- or a comma-separated list of colour stops (e.g. `"#ff0000, #0000ff"`) which becomes
+--- `linear-gradient(to right, #ff0000, #0000ff)`.
+--- @param value string|nil The raw attribute value
+--- @return string|nil A CSS gradient value or nil
+local function parse_gradient(value)
+  if value == nil then return nil end
+  local str = pandoc.utils.stringify(value)
+  if str == '' then return nil end
+  if str:match('^%s*linear%-gradient%s*%(') or str:match('^%s*radial%-gradient%s*%(') then
+    return str
+  end
+  return 'linear-gradient(to right, ' .. str .. ')'
+end
+
+--- Strip every input-alias attribute consumed by the filter so they do not leak to output.
+--- @param attributes table The element attributes (mutated in place)
+local function strip_alias_attributes(attributes)
+  local aliases = {
+    'ink', 'fg', 'colour', 'color',
+    'paper', 'bg', 'bg-colour', 'bg-color',
+    'bc', 'border-colour', 'border-color',
+    'bs', 'border-style',
+    'par', 'opacity', 'gradient'
+  }
+  for _, name in ipairs(aliases) do
+    attributes[name] = nil
+  end
+end
+
+--- Applies HTML styling to an element.
+--- Handles foreground, background, border, opacity, and (for blocks) gradient fills.
 --- @param element table The element to style
---- @param settings table The highlight settings
+--- @param settings table The highlight settings keyed by theme (light/dark)
 --- @param is_block boolean Whether this is a block-level element
 --- @param constructor any The Pandoc constructor (pandoc.Span or pandoc.Div)
 --- @return table The styled element(s)
@@ -71,6 +205,8 @@ local function apply_html_styling(element, settings, is_block, constructor)
     local bg_colour = settings[theme].bg_colour
     local border_colour = settings[theme].border_colour
     local border_style = settings[theme].border_style
+    local opacity = settings[theme].opacity
+    local gradient = settings[theme].gradient
 
     for k, v in pairs(element.attributes) do
       themed_element.attributes[k] = v
@@ -85,28 +221,32 @@ local function apply_html_styling(element, settings, is_block, constructor)
     themed_element.classes = themed_element.classes or {}
     table.insert(themed_element.classes, theme .. '-content')
 
+    strip_alias_attributes(themed_element.attributes)
+
     if colour ~= nil then
-      themed_element.attributes['colour'] = nil
-      themed_element.attributes['color'] = nil
       themed_element.attributes['style'] = themed_element.attributes['style'] .. 'color: ' .. colour .. ';'
     end
 
-    if bg_colour ~= nil then
-      themed_element.attributes['bg-colour'] = nil
-      themed_element.attributes['bg-color'] = nil
+    if is_block and gradient ~= nil then
       themed_element.attributes['style'] = themed_element.attributes['style'] ..
-          'border-radius: 0.2rem; padding: ' .. padding .. ';' .. 'background-color: ' .. bg_colour .. ';'
+          'border-radius: 0.2rem; padding: ' .. padding .. ';' ..
+          'background-image: ' .. gradient .. ';'
+    elseif bg_colour ~= nil then
+      local bg_value = opacity ~= nil and apply_opacity_css(bg_colour, opacity) or bg_colour
+      themed_element.attributes['style'] = themed_element.attributes['style'] ..
+          'border-radius: 0.2rem; padding: ' .. padding .. ';' ..
+          'background-color: ' .. bg_value .. ';'
     end
 
     if border_colour ~= nil then
-      themed_element.attributes['bc'] = nil
-      themed_element.attributes['border-colour'] = nil
-      themed_element.attributes['border-color'] = nil
-      themed_element.attributes['bs'] = nil
-      themed_element.attributes['border-style'] = nil
       local style = border_style or 'solid'
       themed_element.attributes['style'] = themed_element.attributes['style'] ..
           'border: 1px ' .. style .. ' ' .. border_colour .. ';'
+    end
+
+    if opacity ~= nil and bg_colour == nil and gradient == nil then
+      themed_element.attributes['style'] = themed_element.attributes['style'] ..
+          'opacity: ' .. tostring(opacity) .. ';'
     end
 
     table.insert(result, themed_element)
@@ -119,7 +259,7 @@ local function apply_html_styling(element, settings, is_block, constructor)
   end
 end
 
---- Applies text and background colour styling for HTML-based outputs
+--- Applies text and background colour styling for HTML-based outputs.
 --- @param span table The span element to modify
 --- @param settings table The highlight settings containing colour and background colour
 --- @return table The modified span with HTML styling
@@ -127,7 +267,7 @@ local function highlight_html(span, settings)
   return apply_html_styling(span, settings, false, pandoc.Span)
 end
 
---- Applies text and background colour styling for HTML-based outputs (block level)
+--- Applies text and background colour styling for HTML-based outputs (block level).
 --- @param div table The div element to modify
 --- @param settings table The highlight settings containing colour and background colour
 --- @return table The modified div with HTML styling
@@ -135,44 +275,62 @@ local function highlight_html_block(div, settings)
   return apply_html_styling(div, settings, true, pandoc.Div)
 end
 
---- Applies text and background colour styling for LaTeX-based outputs
+--- Applies text and background colour styling for LaTeX-based outputs.
+--- Invalid colours are reported and the corresponding effect is skipped rather than crashing.
 --- @param span table The span element to modify
---- @param colour string The text colour to apply
---- @param bg_colour string The background colour to apply
---- @param border_colour string The border colour to apply
---- @param border_style string The border style to apply
+--- @param colour string|nil The text colour to apply
+--- @param bg_colour string|nil The background colour to apply
+--- @param border_colour string|nil The border colour to apply
+--- @param border_style string|nil The border style to apply
 --- @param par boolean Whether to wrap in a paragraph box
 --- @return table The span content with LaTeX markup
 local function highlight_latex(span, colour, bg_colour, border_colour, border_style, par)
   local is_lualatex = quarto.doc.pdf_engine() == 'lualatex'
 
-  if is_lualatex and bg_colour ~= nil then
+  local colour_hex = to_hex6(colour)
+  local bg_hex = to_hex6(bg_colour)
+  local border_hex = to_hex6(border_colour)
+
+  if colour ~= nil and colour_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring foreground colour "' .. colour .. '" for LaTeX output: not convertible to hex.'
+    )
+  end
+  if bg_colour ~= nil and bg_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring background colour "' .. bg_colour .. '" for LaTeX output: not convertible to hex.'
+    )
+  end
+  if border_colour ~= nil and border_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring border colour "' .. border_colour .. '" for LaTeX output: not convertible to hex.'
+    )
+  end
+
+  if is_lualatex and bg_hex ~= nil then
     quarto.doc.use_latex_package('luacolor, lua-ul')
   end
 
-  if border_colour ~= nil then
+  if border_hex ~= nil then
     quarto.doc.use_latex_package('tikz')
   end
 
-  local colour_open, colour_close
-  if colour == nil then
-    colour_open = ''
-    colour_close = ''
-  else
-    colour_open = '\\textcolor[HTML]{' .. colour:gsub('^#', '') .. '}{'
+  local colour_open, colour_close = '', ''
+  if colour_hex ~= nil then
+    colour_open = '\\textcolor[HTML]{' .. colour_hex .. '}{'
     colour_close = '}'
   end
 
-  local bg_colour_open, bg_colour_close
-  if bg_colour == nil then
-    bg_colour_open = ''
-    bg_colour_close = ''
-  else
+  local bg_colour_open, bg_colour_close = '', ''
+  if bg_hex ~= nil then
     if is_lualatex then
-      bg_colour_open = '\\highLight[{[HTML]{' .. bg_colour:gsub('^#', '') .. '}}]{'
+      bg_colour_open = '\\highLight[{[HTML]{' .. bg_hex .. '}}]{'
       bg_colour_close = '}'
     else
-      bg_colour_open = '\\colorbox[HTML]{' .. bg_colour:gsub('^#', '') .. '}{'
+      bg_colour_open = '\\colorbox[HTML]{' .. bg_hex .. '}{'
       bg_colour_close = '}'
     end
   end
@@ -182,12 +340,8 @@ local function highlight_latex(span, colour, bg_colour, border_colour, border_st
     bg_colour_close = '}' .. bg_colour_close
   end
 
-  local border_open, border_close
-  if border_colour == nil then
-    border_open = ''
-    border_close = ''
-  else
-    -- Map border styles to TikZ line styles
+  local border_open, border_close = '', ''
+  if border_hex ~= nil then
     local tikz_style = ''
     if border_style == 'dashed' then
       tikz_style = ', dashed'
@@ -198,9 +352,9 @@ local function highlight_latex(span, colour, bg_colour, border_colour, border_st
     end
 
     border_open = '\\tikz[baseline=(text.base)]{\\node[draw={rgb,255:red,' ..
-        tonumber(border_colour:sub(2, 3), 16) .. ';green,' ..
-        tonumber(border_colour:sub(4, 5), 16) .. ';blue,' ..
-        tonumber(border_colour:sub(6, 7), 16) .. '}' .. tikz_style .. ', inner sep=0.1em] (text) {\\strut '
+        tonumber(border_hex:sub(1, 2), 16) .. ';green,' ..
+        tonumber(border_hex:sub(3, 4), 16) .. ';blue,' ..
+        tonumber(border_hex:sub(5, 6), 16) .. '}' .. tikz_style .. ', inner sep=0.1em] (text) {\\strut '
     border_close = '};}'
   end
 
@@ -213,17 +367,41 @@ local function highlight_latex(span, colour, bg_colour, border_colour, border_st
   return span.content
 end
 
---- Applies text and background colour styling for LaTeX-based outputs (block level)
+--- Applies text and background colour styling for LaTeX-based outputs (block level).
+--- Invalid colours are reported and the corresponding effect is skipped.
 --- @param div table The div element to modify
---- @param colour string The text colour to apply
---- @param bg_colour string The background colour to apply
---- @param border_colour string The border colour to apply
---- @param border_style string The border style to apply
+--- @param colour string|nil The text colour to apply
+--- @param bg_colour string|nil The background colour to apply
+--- @param border_colour string|nil The border colour to apply
+--- @param border_style string|nil The border style to apply
 --- @return table A modified div with LaTeX environment wrapping
 local function highlight_latex_block(div, colour, bg_colour, border_colour, border_style)
   local is_lualatex = quarto.doc.pdf_engine() == 'lualatex'
 
-  if bg_colour ~= nil then
+  local colour_hex = to_hex6(colour)
+  local bg_hex = to_hex6(bg_colour)
+  local border_hex = to_hex6(border_colour)
+
+  if colour ~= nil and colour_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring foreground colour "' .. colour .. '" for LaTeX output: not convertible to hex.'
+    )
+  end
+  if bg_colour ~= nil and bg_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring background colour "' .. bg_colour .. '" for LaTeX output: not convertible to hex.'
+    )
+  end
+  if border_colour ~= nil and border_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring border colour "' .. border_colour .. '" for LaTeX output: not convertible to hex.'
+    )
+  end
+
+  if bg_hex ~= nil then
     if is_lualatex then
       quarto.doc.use_latex_package('luacolor, lua-ul')
     else
@@ -231,15 +409,14 @@ local function highlight_latex_block(div, colour, bg_colour, border_colour, bord
     end
   end
 
-  if border_colour ~= nil then
+  if border_hex ~= nil then
     quarto.doc.use_latex_package('tikz')
   end
 
   local latex_begin = ''
   local latex_end = ''
 
-  if border_colour ~= nil then
-    -- Map border styles to TikZ line styles
+  if border_hex ~= nil then
     local tikz_style = ''
     if border_style == 'dashed' then
       tikz_style = ', dashed'
@@ -250,58 +427,56 @@ local function highlight_latex_block(div, colour, bg_colour, border_colour, bord
     end
 
     latex_begin = '\\begin{tikzpicture}\\node[draw={rgb,255:red,' ..
-        tonumber(border_colour:sub(2, 3), 16) .. ';green,' ..
-        tonumber(border_colour:sub(4, 5), 16) .. ';blue,' ..
-        tonumber(border_colour:sub(6, 7), 16) ..
+        tonumber(border_hex:sub(1, 2), 16) .. ';green,' ..
+        tonumber(border_hex:sub(3, 4), 16) .. ';blue,' ..
+        tonumber(border_hex:sub(5, 6), 16) ..
         '}' .. tikz_style .. ', inner sep=0.5em, text width=\\dimexpr\\linewidth-1em\\relax]{'
     latex_end = '};\\end{tikzpicture}'
 
-    if colour ~= nil and bg_colour ~= nil then
+    if colour_hex ~= nil and bg_hex ~= nil then
       if is_lualatex then
         latex_begin = latex_begin ..
-            '{\\color[HTML]{' .. colour:gsub('^#', '') .. '}\\highLight[{[HTML]{' .. bg_colour:gsub('^#', '') .. '}}]{'
+            '{\\color[HTML]{' .. colour_hex .. '}\\highLight[{[HTML]{' .. bg_hex .. '}}]{'
         latex_end = '}}' .. latex_end
       else
         latex_begin = latex_begin ..
-            '\\colorbox[HTML]{' ..
-            bg_colour:gsub('^#', '') ..
-            '}{\\parbox{\\dimexpr\\linewidth-2em}{\\color[HTML]{' .. colour:gsub('^#', '') .. '}'
+            '\\colorbox[HTML]{' .. bg_hex ..
+            '}{\\parbox{\\dimexpr\\linewidth-2em}{\\color[HTML]{' .. colour_hex .. '}'
         latex_end = '}}' .. latex_end
       end
-    elseif bg_colour ~= nil then
+    elseif bg_hex ~= nil then
       if is_lualatex then
-        latex_begin = latex_begin .. '\\highLight[{[HTML]{' .. bg_colour:gsub('^#', '') .. '}}]{'
+        latex_begin = latex_begin .. '\\highLight[{[HTML]{' .. bg_hex .. '}}]{'
         latex_end = '}' .. latex_end
       else
         latex_begin = latex_begin ..
-            '\\colorbox[HTML]{' .. bg_colour:gsub('^#', '') .. '}{\\parbox{\\dimexpr\\linewidth-2em}{'
+            '\\colorbox[HTML]{' .. bg_hex .. '}{\\parbox{\\dimexpr\\linewidth-2em}{'
         latex_end = '}}' .. latex_end
       end
-    elseif colour ~= nil then
-      latex_begin = latex_begin .. '{\\color[HTML]{' .. colour:gsub('^#', '') .. '}'
+    elseif colour_hex ~= nil then
+      latex_begin = latex_begin .. '{\\color[HTML]{' .. colour_hex .. '}'
       latex_end = '}' .. latex_end
     end
-  elseif colour ~= nil and bg_colour ~= nil then
+  elseif colour_hex ~= nil and bg_hex ~= nil then
     if is_lualatex then
       latex_begin = '{\\color[HTML]{' ..
-          colour:gsub('^#', '') .. '}\\highLight[{[HTML]{' .. bg_colour:gsub('^#', '') .. '}}]{'
+          colour_hex .. '}\\highLight[{[HTML]{' .. bg_hex .. '}}]{'
       latex_end = '}}'
     else
-      latex_begin = '\\colorbox[HTML]{' ..
-          bg_colour:gsub('^#', '') ..
-          '}{\\parbox{\\dimexpr\\linewidth-2\\fboxsep}{\\color[HTML]{' .. colour:gsub('^#', '') .. '}'
+      latex_begin = '\\colorbox[HTML]{' .. bg_hex ..
+          '}{\\parbox{\\dimexpr\\linewidth-2\\fboxsep}{\\color[HTML]{' .. colour_hex .. '}'
       latex_end = '}}'
     end
-  elseif bg_colour ~= nil then
+  elseif bg_hex ~= nil then
     if is_lualatex then
-      latex_begin = '\\highLight[{[HTML]{' .. bg_colour:gsub('^#', '') .. '}}]{'
+      latex_begin = '\\highLight[{[HTML]{' .. bg_hex .. '}}]{'
       latex_end = '}'
     else
-      latex_begin = '\\colorbox[HTML]{' .. bg_colour:gsub('^#', '') .. '}{\\parbox{\\dimexpr\\linewidth-2\\fboxsep}{'
+      latex_begin = '\\colorbox[HTML]{' .. bg_hex .. '}{\\parbox{\\dimexpr\\linewidth-2\\fboxsep}{'
       latex_end = '}}'
     end
-  elseif colour ~= nil then
-    latex_begin = '{\\color[HTML]{' .. colour:gsub('^#', '') .. '}'
+  elseif colour_hex ~= nil then
+    latex_begin = '{\\color[HTML]{' .. colour_hex .. '}'
     latex_end = '}'
   end
 
@@ -311,23 +486,45 @@ local function highlight_latex_block(div, colour, bg_colour, border_colour, bord
   return div.content
 end
 
---- Applies text and background colour styling for Word documents
+--- Applies text and background colour styling for Word documents.
 --- @param span table The span element to modify
---- @param colour string The text colour to apply
---- @param bg_colour string The background colour to apply
---- @param border_colour string The border colour to apply
---- @param border_style string The border style to apply
+--- @param colour string|nil The text colour to apply
+--- @param bg_colour string|nil The background colour to apply
+--- @param border_colour string|nil The border colour to apply
+--- @param border_style string|nil The border style to apply
 --- @return table The span content with OpenXML markup for Word
 local function highlight_openxml_docx(span, colour, bg_colour, border_colour, border_style)
+  local colour_hex = to_hex6(colour)
+  local bg_hex = to_hex6(bg_colour)
+  local border_hex = to_hex6(border_colour)
+
+  if colour ~= nil and colour_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring foreground colour "' .. colour .. '" for Word output: not convertible to hex.'
+    )
+  end
+  if bg_colour ~= nil and bg_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring background colour "' .. bg_colour .. '" for Word output: not convertible to hex.'
+    )
+  end
+  if border_colour ~= nil and border_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring border colour "' .. border_colour .. '" for Word output: not convertible to hex.'
+    )
+  end
+
   local spec = '<w:r><w:rPr>'
-  if bg_colour ~= nil then
-    spec = spec .. '<w:shd w:val="clear" w:fill="' .. bg_colour:gsub('^#', '') .. '"/>'
+  if bg_hex ~= nil then
+    spec = spec .. '<w:shd w:val="clear" w:fill="' .. bg_hex .. '"/>'
   end
-  if colour ~= nil then
-    spec = spec .. '<w:color w:val="' .. colour:gsub('^#', '') .. '"/>'
+  if colour_hex ~= nil then
+    spec = spec .. '<w:color w:val="' .. colour_hex .. '"/>'
   end
-  if border_colour ~= nil then
-    -- Map border styles to Word border values
+  if border_hex ~= nil then
     local word_style = 'single'
     if border_style == 'dashed' then
       word_style = 'dashed'
@@ -337,7 +534,7 @@ local function highlight_openxml_docx(span, colour, bg_colour, border_colour, bo
       word_style = 'double'
     end
     spec = spec ..
-        '<w:bdr w:val="' .. word_style .. '" w:sz="4" w:space="0" w:color="' .. border_colour:gsub('^#', '') .. '"/>'
+        '<w:bdr w:val="' .. word_style .. '" w:sz="4" w:space="0" w:color="' .. border_hex .. '"/>'
   end
   spec = spec .. '</w:rPr><w:t>'
 
@@ -347,20 +544,42 @@ local function highlight_openxml_docx(span, colour, bg_colour, border_colour, bo
   return span.content
 end
 
---- Applies text and background colour styling for Word documents (block level)
+--- Applies text and background colour styling for Word documents (block level).
 --- @param div table The div element to modify
---- @param colour string The text colour to apply
---- @param bg_colour string The background colour to apply
---- @param border_colour string The border colour to apply
---- @param border_style string The border style to apply
+--- @param colour string|nil The text colour to apply
+--- @param bg_colour string|nil The background colour to apply
+--- @param border_colour string|nil The border colour to apply
+--- @param border_style string|nil The border style to apply
 --- @return table The div content with OpenXML markup for Word
 local function highlight_openxml_docx_block(div, colour, bg_colour, border_colour, border_style)
-  local spec = '<w:pPr>'
-  if bg_colour ~= nil then
-    spec = spec .. '<w:shd w:val="clear" w:fill="' .. bg_colour:gsub('^#', '') .. '"/>'
+  local colour_hex = to_hex6(colour)
+  local bg_hex = to_hex6(bg_colour)
+  local border_hex = to_hex6(border_colour)
+
+  if colour ~= nil and colour_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring foreground colour "' .. colour .. '" for Word output: not convertible to hex.'
+    )
   end
-  if border_colour ~= nil then
-    -- Map border styles to Word border values
+  if bg_colour ~= nil and bg_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring background colour "' .. bg_colour .. '" for Word output: not convertible to hex.'
+    )
+  end
+  if border_colour ~= nil and border_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring border colour "' .. border_colour .. '" for Word output: not convertible to hex.'
+    )
+  end
+
+  local spec = '<w:pPr>'
+  if bg_hex ~= nil then
+    spec = spec .. '<w:shd w:val="clear" w:fill="' .. bg_hex .. '"/>'
+  end
+  if border_hex ~= nil then
     local word_style = 'single'
     if border_style == 'dashed' then
       word_style = 'dashed'
@@ -370,23 +589,23 @@ local function highlight_openxml_docx_block(div, colour, bg_colour, border_colou
       word_style = 'double'
     end
     local border_spec = '<w:pBdr><w:top w:val="' ..
-        word_style .. '" w:sz="4" w:space="1" w:color="' .. border_colour:gsub('^#', '') .. '"/>' ..
-        '<w:left w:val="' .. word_style .. '" w:sz="4" w:space="1" w:color="' .. border_colour:gsub('^#', '') .. '"/>' ..
+        word_style .. '" w:sz="4" w:space="1" w:color="' .. border_hex .. '"/>' ..
+        '<w:left w:val="' .. word_style .. '" w:sz="4" w:space="1" w:color="' .. border_hex .. '"/>' ..
         '<w:bottom w:val="' ..
-        word_style .. '" w:sz="4" w:space="1" w:color="' .. border_colour:gsub('^#', '') .. '"/>' ..
+        word_style .. '" w:sz="4" w:space="1" w:color="' .. border_hex .. '"/>' ..
         '<w:right w:val="' ..
-        word_style .. '" w:sz="4" w:space="1" w:color="' .. border_colour:gsub('^#', '') .. '"/></w:pBdr>'
+        word_style .. '" w:sz="4" w:space="1" w:color="' .. border_hex .. '"/></w:pBdr>'
     spec = spec .. border_spec
   end
   spec = spec .. '</w:pPr>'
 
   table.insert(div.content, 1, pandoc.RawBlock('openxml', spec))
 
-  if colour ~= nil then
+  if colour_hex ~= nil then
     for idx = 2, #div.content do
       if div.content[idx].t == 'Para' or div.content[idx].t == 'Plain' then
         local para = div.content[idx]
-        local colour_spec = '<w:r><w:rPr><w:color w:val="' .. colour:gsub('^#', '') .. '"/></w:rPr><w:t>'
+        local colour_spec = '<w:r><w:rPr><w:color w:val="' .. colour_hex .. '"/></w:rPr><w:t>'
         table.insert(para.content, 1, pandoc.RawInline('openxml', colour_spec))
         table.insert(para.content, pandoc.RawInline('openxml', '</w:t></w:r>'))
       end
@@ -396,22 +615,50 @@ local function highlight_openxml_docx_block(div, colour, bg_colour, border_colou
   return div.content
 end
 
---- Applies text and background colour styling for PowerPoint presentations
+--- Warn once per render when PowerPoint silently discards a border colour.
+--- @param scope string Either "inline" or "block" for the warning context
+local function warn_pptx_border_discarded(scope)
+  if pptx_border_warning_shown then return end
+  log.log_warning(
+    EXTENSION_NAME,
+    'PowerPoint does not support borders on ' .. scope ..
+    ' text runs; the border colour is discarded. Use a shape or table cell for borders.'
+  )
+  pptx_border_warning_shown = true
+end
+
+--- Applies text and background colour styling for PowerPoint presentations.
 --- @param span table The span element to modify
---- @param colour string The text colour to apply
---- @param bg_colour string The background colour to apply
---- @param border_colour string The border colour to apply (not supported for inline text)
+--- @param colour string|nil The text colour to apply
+--- @param bg_colour string|nil The background colour to apply
+--- @param border_colour string|nil The border colour (warned and discarded)
 --- @return table Raw inline containing OpenXML markup for PowerPoint
 local function highlight_openxml_pptx(span, colour, bg_colour, border_colour)
-  -- Note: PowerPoint does not support rectangular borders on inline text runs
-  -- Border colour is ignored for inline spans in PowerPoint format
-  -- Use block-level divs for border support
-  local spec = '<a:r><a:rPr dirty="0">'
-  if colour ~= nil then
-    spec = spec .. '<a:solidFill><a:srgbClr val="' .. colour:gsub('^#', '') .. '" /></a:solidFill>'
+  local colour_hex = to_hex6(colour)
+  local bg_hex = to_hex6(bg_colour)
+
+  if colour ~= nil and colour_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring foreground colour "' .. colour .. '" for PowerPoint output: not convertible to hex.'
+    )
   end
-  if bg_colour ~= nil then
-    spec = spec .. '<a:highlight><a:srgbClr val="' .. bg_colour:gsub('^#', '') .. '" /></a:highlight>'
+  if bg_colour ~= nil and bg_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring background colour "' .. bg_colour .. '" for PowerPoint output: not convertible to hex.'
+    )
+  end
+  if border_colour ~= nil then
+    warn_pptx_border_discarded('inline')
+  end
+
+  local spec = '<a:r><a:rPr dirty="0">'
+  if colour_hex ~= nil then
+    spec = spec .. '<a:solidFill><a:srgbClr val="' .. colour_hex .. '" /></a:solidFill>'
+  end
+  if bg_hex ~= nil then
+    spec = spec .. '<a:highlight><a:srgbClr val="' .. bg_hex .. '" /></a:highlight>'
   end
   spec = spec .. '</a:rPr><a:t>'
 
@@ -423,16 +670,32 @@ local function highlight_openxml_pptx(span, colour, bg_colour, border_colour)
   return pandoc.RawInline('openxml', spec .. span_content_string .. '</a:t></a:r>')
 end
 
---- Applies text and background colour styling for PowerPoint presentations (block level)
+--- Applies text and background colour styling for PowerPoint presentations (block level).
 --- @param div table The div element to modify
---- @param colour string The text colour to apply
---- @param bg_colour string The background colour to apply
---- @param border_colour string The border colour to apply (not supported)
+--- @param colour string|nil The text colour to apply
+--- @param bg_colour string|nil The background colour to apply
+--- @param border_colour string|nil The border colour (warned and discarded)
 --- @return table The div content with OpenXML markup for PowerPoint
 local function highlight_openxml_pptx_block(div, colour, bg_colour, border_colour)
-  -- Note: PowerPoint does not support rectangular borders on text paragraphs
-  -- Border colour is ignored for PowerPoint format
-  -- Borders in PowerPoint can only be applied to shapes or table cells
+  local colour_hex = to_hex6(colour)
+  local bg_hex = to_hex6(bg_colour)
+
+  if colour ~= nil and colour_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring foreground colour "' .. colour .. '" for PowerPoint output: not convertible to hex.'
+    )
+  end
+  if bg_colour ~= nil and bg_hex == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring background colour "' .. bg_colour .. '" for PowerPoint output: not convertible to hex.'
+    )
+  end
+  if border_colour ~= nil then
+    warn_pptx_border_discarded('block')
+  end
+
   for idx = 1, #div.content do
     if div.content[idx].t == 'Para' or div.content[idx].t == 'Plain' then
       local para = div.content[idx]
@@ -442,11 +705,11 @@ local function highlight_openxml_pptx_block(div, colour, bg_colour, border_colou
       end
 
       local spec = '<a:r><a:rPr dirty="0">'
-      if colour ~= nil then
-        spec = spec .. '<a:solidFill><a:srgbClr val="' .. colour:gsub('^#', '') .. '" /></a:solidFill>'
+      if colour_hex ~= nil then
+        spec = spec .. '<a:solidFill><a:srgbClr val="' .. colour_hex .. '" /></a:solidFill>'
       end
-      if bg_colour ~= nil then
-        spec = spec .. '<a:highlight><a:srgbClr val="' .. bg_colour:gsub('^#', '') .. '" /></a:highlight>'
+      if bg_hex ~= nil then
+        spec = spec .. '<a:highlight><a:srgbClr val="' .. bg_hex .. '" /></a:highlight>'
       end
       spec = spec .. '</a:rPr><a:t>'
 
@@ -457,27 +720,24 @@ local function highlight_openxml_pptx_block(div, colour, bg_colour, border_colou
   return div.content
 end
 
---- Applies text and background colour styling for Typst output
+--- Applies text and background colour styling for Typst output.
 --- @param span table The span element to modify
---- @param colour string The text colour to apply
---- @param bg_colour string The background colour to apply
---- @param border_colour string The border colour to apply
---- @param border_style string The border style to apply
+--- @param colour string|nil The text colour to apply
+--- @param bg_colour string|nil The background colour to apply
+--- @param border_colour string|nil The border colour to apply
+--- @param border_style string|nil The border style to apply
 --- @return table The span content with Typst markup
 local function highlight_typst(span, colour, bg_colour, border_colour, border_style)
-  local colour_open, colour_close
-  if colour == nil then
-    colour_open = ''
-    colour_close = ''
-  else
+  local colour_open, colour_close = '', ''
+  if colour ~= nil then
     colour_open = '#text(' .. colour .. ')['
     colour_close = ']'
   end
 
-  local bg_colour_open, bg_colour_close
-  local border_open, border_close
+  local bg_colour_open, bg_colour_close = '', ''
+  local border_open, border_close = '', ''
 
-  -- Build Typst stroke specification with optional dash pattern
+  -- Build Typst stroke specification with optional dash pattern.
   local function build_stroke(stroke_colour, style)
     if style == 'dashed' then
       return '(paint: ' .. stroke_colour .. ', dash: "dashed")'
@@ -490,29 +750,18 @@ local function highlight_typst(span, colour, bg_colour, border_colour, border_st
     end
   end
 
-  -- When both border and background are present, combine them in a single box
   if border_colour ~= nil and bg_colour ~= nil then
     local stroke_spec = build_stroke(border_colour, border_style)
-    border_open = '#box(stroke: ' .. stroke_spec .. ', fill: ' .. bg_colour .. ', inset: (x: 0.2em, y: 0.45em))['
+    border_open = '#box(stroke: ' .. stroke_spec .. ', fill: ' .. bg_colour ..
+        ', inset: (x: 0.2em, y: 0.45em))['
     border_close = ']'
-    bg_colour_open = ''
-    bg_colour_close = ''
   elseif border_colour ~= nil then
     local stroke_spec = build_stroke(border_colour, border_style)
     border_open = '#box(stroke: ' .. stroke_spec .. ', inset: (x: 0.2em, y: 0.45em))['
     border_close = ']'
-    bg_colour_open = ''
-    bg_colour_close = ''
   elseif bg_colour ~= nil then
     bg_colour_open = '#highlight(fill: ' .. bg_colour .. ')['
     bg_colour_close = ']'
-    border_open = ''
-    border_close = ''
-  else
-    bg_colour_open = ''
-    bg_colour_close = ''
-    border_open = ''
-    border_close = ''
   end
 
   table.insert(
@@ -527,27 +776,24 @@ local function highlight_typst(span, colour, bg_colour, border_colour, border_st
   return span.content
 end
 
---- Applies text and background colour styling for Typst output (block level)
+--- Applies text and background colour styling for Typst output (block level).
 --- @param div table The div element to modify
---- @param colour string The text colour to apply
---- @param bg_colour string The background colour to apply
---- @param border_colour string The border colour to apply
---- @param border_style string The border style to apply
+--- @param colour string|nil The text colour to apply
+--- @param bg_colour string|nil The background colour to apply
+--- @param border_colour string|nil The border colour to apply
+--- @param border_style string|nil The border style to apply
 --- @return table The div content with Typst markup
 local function highlight_typst_block(div, colour, bg_colour, border_colour, border_style)
-  local colour_open, colour_close
-  if colour == nil then
-    colour_open = ''
-    colour_close = ''
-  else
+  local colour_open, colour_close = '', ''
+  if colour ~= nil then
     colour_open = '#text(' .. colour .. ')['
     colour_close = ']'
   end
 
-  local bg_colour_open, bg_colour_close
-  local border_open, border_close
+  local bg_colour_open, bg_colour_close = '', ''
+  local border_open, border_close = '', ''
 
-  -- Build Typst stroke specification with optional dash pattern
+  -- Build Typst stroke specification with optional dash pattern.
   local function build_stroke(stroke_colour, style)
     if style == 'dashed' then
       return '(paint: ' .. stroke_colour .. ', dash: "dashed")'
@@ -560,30 +806,19 @@ local function highlight_typst_block(div, colour, bg_colour, border_colour, bord
     end
   end
 
-  -- When both border and background are present, combine them in a single block
   if border_colour ~= nil and bg_colour ~= nil then
     local stroke_spec = build_stroke(border_colour, border_style)
     border_open = '#block(stroke: ' ..
         stroke_spec .. ', fill: ' .. bg_colour .. ', inset: (x: 0.5em, y: 0.9em), radius: 0.2em)['
     border_close = ']'
-    bg_colour_open = ''
-    bg_colour_close = ''
   elseif border_colour ~= nil then
     local stroke_spec = build_stroke(border_colour, border_style)
-    border_open = '#block(stroke: ' .. stroke_spec .. ', inset: (x: 0.5em, y: 0.9em), radius: 0.2em)['
+    border_open = '#block(stroke: ' .. stroke_spec ..
+        ', inset: (x: 0.5em, y: 0.9em), radius: 0.2em)['
     border_close = ']'
-    bg_colour_open = ''
-    bg_colour_close = ''
   elseif bg_colour ~= nil then
     bg_colour_open = '#block(fill: ' .. bg_colour .. ', inset: 0.5em, radius: 0.2em)['
     bg_colour_close = ']'
-    border_open = ''
-    border_close = ''
-  else
-    bg_colour_open = ''
-    bg_colour_close = ''
-    border_open = ''
-    border_close = ''
   end
 
   table.insert(
@@ -598,7 +833,7 @@ local function highlight_typst_block(div, colour, bg_colour, border_colour, bord
   return div.content
 end
 
---- Extracts colour attributes from element attributes
+--- Extracts colour attributes from element attributes.
 --- @param attributes table The element attributes
 --- @return string|nil colour The foreground colour
 --- @return string|nil bg_colour The background colour
@@ -612,13 +847,15 @@ local function get_colour_attributes(attributes)
   return colour, bg_colour, border_colour, border_style
 end
 
---- Processes colour settings for light and dark themes
+--- Processes colour settings for light and dark themes.
 --- @param colour string|nil The foreground colour
 --- @param bg_colour string|nil The background colour
 --- @param border_colour string|nil The border colour
 --- @param border_style string|nil The border style
+--- @param opacity number|nil The opacity (HTML only)
+--- @param gradient string|nil The block-level gradient (HTML only)
 --- @return table|nil highlight_settings The processed highlight settings
-local function process_highlight_settings(colour, bg_colour, border_colour, border_style)
+local function process_highlight_settings(colour, bg_colour, border_colour, border_style, opacity, gradient)
   local highlight_settings = {}
 
   if quarto.brand.has_mode('light') or quarto.brand.has_mode('dark') then
@@ -626,19 +863,23 @@ local function process_highlight_settings(colour, bg_colour, border_colour, bord
     for _, mode in ipairs(modes) do
       if quarto.brand.has_mode(mode) then
         highlight_settings[mode] = {
-          colour = get_brand_colour(mode, colour),
-          bg_colour = get_brand_colour(mode, bg_colour),
-          border_colour = get_brand_colour(mode, border_colour),
-          border_style = border_style
+          colour = get_brand_colour(mode, colour, 'foreground colour'),
+          bg_colour = get_brand_colour(mode, bg_colour, 'background colour'),
+          border_colour = get_brand_colour(mode, border_colour, 'border colour'),
+          border_style = border_style,
+          opacity = opacity,
+          gradient = gradient
         }
       end
     end
   else
     highlight_settings.light = {
-      colour = get_brand_colour('light', colour),
-      bg_colour = get_brand_colour('light', bg_colour),
-      border_colour = get_brand_colour('light', border_colour),
-      border_style = border_style
+      colour = get_brand_colour('light', colour, 'foreground colour'),
+      bg_colour = get_brand_colour('light', bg_colour, 'background colour'),
+      border_colour = get_brand_colour('light', border_colour, 'border colour'),
+      border_style = border_style,
+      opacity = opacity,
+      gradient = gradient
     }
   end
 
@@ -654,12 +895,13 @@ local function process_highlight_settings(colour, bg_colour, border_colour, bord
 end
 
 --- Main filter function that processes span elements and applies highlighting
---- based on the output format and specified attributes
+--- based on the output format and specified attributes.
 --- @param span table The span element from the document
 --- @return table The modified span or span content with appropriate styling
 local function highlight(span)
   local colour, bg_colour, border_colour, border_style = get_colour_attributes(span.attributes)
-  local highlight_settings = process_highlight_settings(colour, bg_colour, border_colour, border_style)
+  local opacity = parse_opacity(span.attributes['opacity'])
+  local highlight_settings = process_highlight_settings(colour, bg_colour, border_colour, border_style, opacity, nil)
 
   if highlight_settings == nil then
     return span
@@ -670,12 +912,12 @@ local function highlight(span)
   border_colour = highlight_settings.light.border_colour
   border_style = highlight_settings.light.border_style
 
-  if colour == nil and bg_colour == nil and border_colour == nil then
+  if colour == nil and bg_colour == nil and border_colour == nil and opacity == nil then
     return span
   end
 
   local par = span.attributes['par'] ~= nil
-  span.attributes['par'] = nil
+  strip_alias_attributes(span.attributes)
 
   if quarto.doc.is_format('html') or quarto.doc.is_format('revealjs') then
     return highlight_html(span, highlight_settings)
@@ -693,12 +935,14 @@ local function highlight(span)
 end
 
 --- Main filter function that processes div elements and applies highlighting
---- based on the output format and specified attributes
+--- based on the output format and specified attributes.
 --- @param div table The div element from the document
 --- @return table The modified div or div content with appropriate styling
 local function highlight_block(div)
   local colour, bg_colour, border_colour, border_style = get_colour_attributes(div.attributes)
-  local highlight_settings = process_highlight_settings(colour, bg_colour, border_colour, border_style)
+  local opacity = parse_opacity(div.attributes['opacity'])
+  local gradient = parse_gradient(div.attributes['gradient'])
+  local highlight_settings = process_highlight_settings(colour, bg_colour, border_colour, border_style, opacity, gradient)
 
   if highlight_settings == nil then
     return div
@@ -709,22 +953,18 @@ local function highlight_block(div)
   border_colour = highlight_settings.light.border_colour
   border_style = highlight_settings.light.border_style
 
-  if colour == nil and bg_colour == nil and border_colour == nil then
+  if colour == nil and bg_colour == nil and border_colour == nil and opacity == nil and gradient == nil then
     return div
   end
 
-  -- Clean up attributes
-  div.attributes['fg'] = nil
-  div.attributes['colour'] = nil
-  div.attributes['color'] = nil
-  div.attributes['bg'] = nil
-  div.attributes['bg-colour'] = nil
-  div.attributes['bg-color'] = nil
-  div.attributes['bc'] = nil
-  div.attributes['border-colour'] = nil
-  div.attributes['border-color'] = nil
-  div.attributes['bs'] = nil
-  div.attributes['border-style'] = nil
+  if gradient ~= nil and not (quarto.doc.is_format('html') or quarto.doc.is_format('revealjs')) then
+    log.log_warning(
+      EXTENSION_NAME,
+      'The "gradient" attribute is only supported in HTML/RevealJS output; ignoring for format "' .. FORMAT .. '".'
+    )
+  end
+
+  strip_alias_attributes(div.attributes)
 
   if quarto.doc.is_format('html') or quarto.doc.is_format('revealjs') then
     return highlight_html_block(div, highlight_settings)

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -105,6 +105,34 @@ local function to_hex6(colour)
   return nil
 end
 
+--- Convert foreground, background, and border colours to 6-character hex for a binary writer
+--- (LaTeX, Word, PowerPoint). Emits a warning for each value that cannot be expressed as hex.
+--- @param colour string|nil The foreground colour value
+--- @param bg_colour string|nil The background colour value
+--- @param border_colour string|nil The border colour value
+--- @param format_label string Human-readable format label used in warnings (e.g. "LaTeX")
+--- @return string|nil, string|nil, string|nil colour_hex, bg_hex, border_hex
+local function resolve_hex_triplet(colour, bg_colour, border_colour, format_label)
+  local pairs_list = {
+    { name = 'foreground colour', value = colour },
+    { name = 'background colour', value = bg_colour },
+    { name = 'border colour',     value = border_colour },
+  }
+  local results = {}
+  for i, entry in ipairs(pairs_list) do
+    local hex = to_hex6(entry.value)
+    if entry.value ~= nil and hex == nil then
+      log.log_warning(
+        EXTENSION_NAME,
+        'Ignoring ' .. entry.name .. ' "' .. entry.value .. '" for ' .. format_label ..
+        ' output: not convertible to hex.'
+      )
+    end
+    results[i] = hex
+  end
+  return results[1], results[2], results[3]
+end
+
 --- Apply opacity to a CSS-style colour value when the colour is a hex code.
 --- Returns the original value unchanged when conversion is not possible (e.g. `var()`, rgb()).
 --- For hex inputs, returns an `rgba()` string.
@@ -287,28 +315,7 @@ end
 local function highlight_latex(span, colour, bg_colour, border_colour, border_style, par)
   local is_lualatex = quarto.doc.pdf_engine() == 'lualatex'
 
-  local colour_hex = to_hex6(colour)
-  local bg_hex = to_hex6(bg_colour)
-  local border_hex = to_hex6(border_colour)
-
-  if colour ~= nil and colour_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring foreground colour "' .. colour .. '" for LaTeX output: not convertible to hex.'
-    )
-  end
-  if bg_colour ~= nil and bg_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring background colour "' .. bg_colour .. '" for LaTeX output: not convertible to hex.'
-    )
-  end
-  if border_colour ~= nil and border_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring border colour "' .. border_colour .. '" for LaTeX output: not convertible to hex.'
-    )
-  end
+  local colour_hex, bg_hex, border_hex = resolve_hex_triplet(colour, bg_colour, border_colour, 'LaTeX')
 
   if is_lualatex and bg_hex ~= nil then
     quarto.doc.use_latex_package('luacolor, lua-ul')
@@ -378,28 +385,7 @@ end
 local function highlight_latex_block(div, colour, bg_colour, border_colour, border_style)
   local is_lualatex = quarto.doc.pdf_engine() == 'lualatex'
 
-  local colour_hex = to_hex6(colour)
-  local bg_hex = to_hex6(bg_colour)
-  local border_hex = to_hex6(border_colour)
-
-  if colour ~= nil and colour_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring foreground colour "' .. colour .. '" for LaTeX output: not convertible to hex.'
-    )
-  end
-  if bg_colour ~= nil and bg_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring background colour "' .. bg_colour .. '" for LaTeX output: not convertible to hex.'
-    )
-  end
-  if border_colour ~= nil and border_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring border colour "' .. border_colour .. '" for LaTeX output: not convertible to hex.'
-    )
-  end
+  local colour_hex, bg_hex, border_hex = resolve_hex_triplet(colour, bg_colour, border_colour, 'LaTeX')
 
   if bg_hex ~= nil then
     if is_lualatex then
@@ -494,28 +480,7 @@ end
 --- @param border_style string|nil The border style to apply
 --- @return table The span content with OpenXML markup for Word
 local function highlight_openxml_docx(span, colour, bg_colour, border_colour, border_style)
-  local colour_hex = to_hex6(colour)
-  local bg_hex = to_hex6(bg_colour)
-  local border_hex = to_hex6(border_colour)
-
-  if colour ~= nil and colour_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring foreground colour "' .. colour .. '" for Word output: not convertible to hex.'
-    )
-  end
-  if bg_colour ~= nil and bg_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring background colour "' .. bg_colour .. '" for Word output: not convertible to hex.'
-    )
-  end
-  if border_colour ~= nil and border_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring border colour "' .. border_colour .. '" for Word output: not convertible to hex.'
-    )
-  end
+  local colour_hex, bg_hex, border_hex = resolve_hex_triplet(colour, bg_colour, border_colour, 'Word')
 
   local spec = '<w:r><w:rPr>'
   if bg_hex ~= nil then
@@ -552,28 +517,7 @@ end
 --- @param border_style string|nil The border style to apply
 --- @return table The div content with OpenXML markup for Word
 local function highlight_openxml_docx_block(div, colour, bg_colour, border_colour, border_style)
-  local colour_hex = to_hex6(colour)
-  local bg_hex = to_hex6(bg_colour)
-  local border_hex = to_hex6(border_colour)
-
-  if colour ~= nil and colour_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring foreground colour "' .. colour .. '" for Word output: not convertible to hex.'
-    )
-  end
-  if bg_colour ~= nil and bg_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring background colour "' .. bg_colour .. '" for Word output: not convertible to hex.'
-    )
-  end
-  if border_colour ~= nil and border_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring border colour "' .. border_colour .. '" for Word output: not convertible to hex.'
-    )
-  end
+  local colour_hex, bg_hex, border_hex = resolve_hex_triplet(colour, bg_colour, border_colour, 'Word')
 
   local spec = '<w:pPr>'
   if bg_hex ~= nil then
@@ -634,21 +578,8 @@ end
 --- @param border_colour string|nil The border colour (warned and discarded)
 --- @return table Raw inline containing OpenXML markup for PowerPoint
 local function highlight_openxml_pptx(span, colour, bg_colour, border_colour)
-  local colour_hex = to_hex6(colour)
-  local bg_hex = to_hex6(bg_colour)
+  local colour_hex, bg_hex = resolve_hex_triplet(colour, bg_colour, nil, 'PowerPoint')
 
-  if colour ~= nil and colour_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring foreground colour "' .. colour .. '" for PowerPoint output: not convertible to hex.'
-    )
-  end
-  if bg_colour ~= nil and bg_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring background colour "' .. bg_colour .. '" for PowerPoint output: not convertible to hex.'
-    )
-  end
   if border_colour ~= nil then
     warn_pptx_border_discarded('inline')
   end
@@ -677,21 +608,8 @@ end
 --- @param border_colour string|nil The border colour (warned and discarded)
 --- @return table The div content with OpenXML markup for PowerPoint
 local function highlight_openxml_pptx_block(div, colour, bg_colour, border_colour)
-  local colour_hex = to_hex6(colour)
-  local bg_hex = to_hex6(bg_colour)
+  local colour_hex, bg_hex = resolve_hex_triplet(colour, bg_colour, nil, 'PowerPoint')
 
-  if colour ~= nil and colour_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring foreground colour "' .. colour .. '" for PowerPoint output: not convertible to hex.'
-    )
-  end
-  if bg_colour ~= nil and bg_hex == nil then
-    log.log_warning(
-      EXTENSION_NAME,
-      'Ignoring background colour "' .. bg_colour .. '" for PowerPoint output: not convertible to hex.'
-    )
-  end
   if border_colour ~= nil then
     warn_pptx_border_discarded('block')
   end

--- a/example.qmd
+++ b/example.qmd
@@ -104,7 +104,7 @@ This is a Quarto extension that allows to highlight text in a document for vario
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-highlight-text@2.2.1
+quarto add mcanouil/quarto-highlight-text@2.3.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -152,10 +152,12 @@ You can use abbreviated attribute names ([v1.1.1](../../releases/tag/1.1.1)):
 
 Supported attributes:
 
-- **Foreground (text) colour**: `ink`, `fg`, `colour`, or `color`
-- **Background colour**: `paper`, `bg`, `bg-colour`, or `bg-color`
-- **Border colour**: `bc`, `border-colour`, or `border-color`
-- **Border style**: `bs` or `border-style` (values: `solid`, `dashed`, `dotted`, `double`; defaults to `solid`)
+- **Foreground (text) colour**: `ink`, `fg`, `colour`, or `color`.
+- **Background colour**: `paper`, `bg`, `bg-colour`, or `bg-color`.
+- **Border colour**: `bc`, `border-colour`, or `border-color`.
+- **Border style**: `bs` or `border-style` (values: `solid`, `dashed`, `dotted`, `double`; defaults to `solid`).
+- **Opacity** (HTML only): `opacity` accepts a number in `[0, 1]` or a percentage (e.g. `"50%"`).
+- **Gradient fill** (HTML block-level only): `gradient` accepts a full `linear-gradient(...)` value or a comma-separated list of colour stops.
 
 ## Font Colour
 
@@ -509,6 +511,78 @@ This block uses brand colours that adapt to light/dark themes.
 In light mode, this appears as white text on red background.
 
 In dark mode, this appears as red text on white background.
+
+:::
+
+:::: {.content-visible when-format="beamer" when-format="revealjs" when-format="pptx"}
+
+---
+
+:::
+
+## Opacity (HTML only)
+
+The `opacity` attribute applies a translucent effect.
+When a background colour is present, only the background is made translucent (foreground text remains readable); otherwise the whole element fades.
+
+```markdown
+[Half-transparent background]{bg="#b22222" opacity="0.5"}
+```
+
+[Half-transparent background]{bg="#b22222" opacity="0.5"}
+
+```markdown
+[Fifty per cent fade]{fg="#b22222" opacity="50%"}
+```
+
+[Fifty per cent fade]{fg="#b22222" opacity="50%"}
+
+## CSS `var()` References (HTML only)
+
+Use CSS custom properties to bind colours to theme variables defined elsewhere in your stylesheet.
+
+```markdown
+[Themed text]{fg="var(--bs-primary)"}
+```
+
+[Themed text]{fg="var(--bs-primary)"}
+
+## Gradient Fills (HTML block-level only)
+
+Block divs accept a `gradient` attribute for CSS gradient fills.
+You can pass either a full `linear-gradient(...)`/`radial-gradient(...)` value or a comma-separated list of colour stops (becomes a left-to-right linear gradient).
+
+```markdown
+::: {gradient="#ff7e5f, #feb47b" fg="#ffffff"}
+
+A simple two-stop linear gradient (left-to-right).
+
+:::
+```
+
+::: {gradient="#ff7e5f, #feb47b" fg="#ffffff"}
+
+A simple two-stop linear gradient (left-to-right).
+
+:::
+
+```markdown
+::: {gradient="linear-gradient(135deg, #00b09b 0%, #2575fc 100%)" fg="#ffffff"}
+
+A diagonal linear gradient with explicit stops.
+
+:::
+```
+
+::: {gradient="linear-gradient(135deg, #00b09b 0%, #2575fc 100%)" fg="#ffffff"}
+
+A diagonal linear gradient with explicit stops.
+
+:::
+
+:::: {.content-visible when-format="beamer" when-format="revealjs" when-format="pptx"}
+
+---
 
 :::
 

--- a/example.qmd
+++ b/example.qmd
@@ -156,8 +156,8 @@ Supported attributes:
 - **Background colour**: `paper`, `bg`, `bg-colour`, or `bg-color`.
 - **Border colour**: `bc`, `border-colour`, or `border-color`.
 - **Border style**: `bs` or `border-style` (values: `solid`, `dashed`, `dotted`, `double`; defaults to `solid`).
-- **Opacity** (HTML only): `opacity` accepts a number in `[0, 1]` or a percentage (e.g. `"50%"`).
-- **Gradient fill** (HTML block-level only): `gradient` accepts a full `linear-gradient(...)` value or a comma-separated list of colour stops.
+- **Opacity** (HTML and Typst): `opacity` accepts a number in `[0, 1]` or a percentage (e.g. `"50%"`).
+- **Gradient fill** (HTML and Typst, block-level only): `gradient` accepts a full `linear-gradient(...)` value or a comma-separated list of colour stops.
 
 ## Font Colour
 
@@ -376,13 +376,11 @@ Using colours defined in the `brand` section of this document's front matter:
 
 ### Deprecated Syntax (Still Supported)
 
-The old `brand-color.` prefix syntax still works but shows a deprecation warning:
+The old `brand-color.` prefix syntax still works but shows a deprecation warning, so it is shown as code only and not rendered here:
 
 ```markdown
 [Using deprecated syntax]{colour="brand-color.fg" bg-colour="brand-color.bg"}
 ```
-
-[Using deprecated syntax]{colour="brand-color.fg" bg-colour="brand-color.bg"}
 
 :::: {.callout-note}
 
@@ -520,7 +518,7 @@ In dark mode, this appears as red text on white background.
 
 :::
 
-## Opacity (HTML only)
+## Opacity (HTML and Typst)
 
 The `opacity` attribute applies a translucent effect.
 When a background colour is present, only the background is made translucent (foreground text remains readable); otherwise the whole element fades.
@@ -545,12 +543,17 @@ Use CSS custom properties to bind colours to theme variables defined elsewhere i
 [Themed text]{fg="var(--bs-primary)"}
 ```
 
+::: {.content-visible when-format="html" when-format="revealjs"}
+
 [Themed text]{fg="var(--bs-primary)"}
 
-## Gradient Fills (HTML block-level only)
+:::
 
-Block divs accept a `gradient` attribute for CSS gradient fills.
+## Gradient Fills (HTML and Typst, block-level)
+
+Block divs accept a `gradient` attribute for gradient fills.
 You can pass either a full `linear-gradient(...)`/`radial-gradient(...)` value or a comma-separated list of colour stops (becomes a left-to-right linear gradient).
+Typst output renders these as native `gradient.linear`/`gradient.radial` fills.
 
 ```markdown
 ::: {gradient="#ff7e5f, #feb47b" fg="#ffffff"}
@@ -560,11 +563,15 @@ A simple two-stop linear gradient (left-to-right).
 :::
 ```
 
+:::: {.content-visible when-format="html" when-format="revealjs" when-format="typst"}
+
 ::: {gradient="#ff7e5f, #feb47b" fg="#ffffff"}
 
 A simple two-stop linear gradient (left-to-right).
 
 :::
+
+::::
 
 ```markdown
 ::: {gradient="linear-gradient(135deg, #00b09b 0%, #2575fc 100%)" fg="#ffffff"}
@@ -574,11 +581,15 @@ A diagonal linear gradient with explicit stops.
 :::
 ```
 
+:::: {.content-visible when-format="html" when-format="revealjs" when-format="typst"}
+
 ::: {gradient="linear-gradient(135deg, #00b09b 0%, #2575fc 100%)" fg="#ffffff"}
 
 A diagonal linear gradient with explicit stops.
 
 :::
+
+::::
 
 :::: {.content-visible when-format="beamer" when-format="revealjs" when-format="pptx"}
 

--- a/example.qmd
+++ b/example.qmd
@@ -104,7 +104,7 @@ This is a Quarto extension that allows to highlight text in a document for vario
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-highlight-text@2.3.0
+quarto add mcanouil/quarto-highlight-text@2.2.1
 ```
 
 This will install the extension under the `_extensions` subdirectory.


### PR DESCRIPTION
- Validate every colour value via the shared `colour.lua` module before passing it to the LaTeX, Word, and PowerPoint writers; non-hex values (named CSS colours, malformed hex) no longer raise a runtime error from `tonumber(...):sub(...)` returning nil, and are skipped with an actionable warning.
- Strip every input-alias attribute (`ink`, `fg`, `paper`, `bg`, `bg-colour`, `bg-color`, `bc`, `border-colour`, `border-color`, `bs`, `border-style`, `par`, `opacity`, `gradient`) inside `apply_html_styling` so they no longer leak as `data-*` attributes in HTML output.
- Emit a single warning per render when a border colour is supplied for PowerPoint inline runs or blocks (PowerPoint cannot draw borders on text runs; the colour is discarded).
- Add CSS custom property references (`var(--...)`) for `colour`, `bg-colour`, and `border-colour` (HTML/RevealJS only); other formats warn and skip.
- Add an `opacity` attribute accepting a number in `[0, 1]` or a percentage; applied to the background when present, otherwise to the element as a whole (HTML/RevealJS only).
- Add a `gradient` attribute on block-level divs accepting a full `linear-gradient(...)`/`radial-gradient(...)` value or a comma-separated list of colour stops (HTML/RevealJS only).
- Document the new attributes in `_schema.yml`, add `highlight-opacity` and `highlight-gradient` snippets, refresh README and example, and bump the version to `2.3.0`.
- Synchronise the shared `colour.lua` module from `creating-quarto-extension/assets/modules`.
