### PR TITLE
fix: validate a colour before writing it for Typst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Validate a colour before writing it for Typst. A CSS named colour, a CSS functional colour, or a typo was wrapped as `rgb("…")` and reached the compiler, stopping the render with `color string contains non-hexadecimal letters`. A value is now converted to a hex code first, so a named colour works as it does elsewhere, and anything that cannot be expressed as hex is skipped with a warning like every other format.
+
 ### Documentation
+
+- docs: Correct the reference, which said a CSS named colour does not work under Typst and that an unusable value stops the render.
 
 - docs: Add a documentation website under `docs/`, built on the `atelier` project type and published to <https://m.canouil.dev/quarto-highlight-text/>.
 - docs: Trim `README.md` to a landing page pointing at the website, and `example.qmd` to a short starting point to copy.

--- a/_extensions/highlight-text/highlight-text.lua
+++ b/_extensions/highlight-text/highlight-text.lua
@@ -27,6 +27,25 @@ local function is_css_var(value)
 end
 
 --- Resolve a colour reference to a concrete colour value.
+--- Convert a colour reference to a 6-character hex (without leading "#").
+--- Brand-resolved values are already concrete; this normalises hex (3 or 6 digits) and named colours.
+--- Returns nil for values that cannot be expressed as a hex code (rgb(), hsl(), CSS var(), Typst rgb()).
+--- @param colour string|nil The colour value
+--- @return string|nil A 6-character hex string without "#", or nil when not expressible as hex
+local function to_hex6(colour)
+  if colour == nil then return nil end
+  if colour_utils.is_named_colour(colour) then
+    return colour_utils.named_to_HTML(colour):gsub('^#', '')
+  end
+  if colour:match('^#%x%x%x%x%x%x$') then
+    return colour:sub(2)
+  end
+  if colour:match('^#%x%x%x$') then
+    return colour_utils.expand_hex_colour(colour):gsub('^#', '')
+  end
+  return nil
+end
+
 --- Brand colour names are resolved via the Quarto brand API.
 --- CSS `var()` references are preserved for HTML output.
 --- Hex/CSS colour values are validated.
@@ -68,8 +87,21 @@ local function get_brand_colour(theme, colour, attribute)
     return brand_colour
   end
 
+  -- Typst's `rgb()` takes a hex string, so a value has to be expressible as one
+  -- before it can be wrapped. Anything else is skipped with a warning, as it is
+  -- in every other format, rather than reaching the Typst compiler and failing
+  -- the whole render.
   if FORMAT:match('typst') then
-    return 'rgb("' .. colour .. '")'
+    local hex = to_hex6(colour)
+    if hex ~= nil then
+      return 'rgb("#' .. hex .. '")'
+    end
+    log.log_warning(
+      EXTENSION_NAME,
+      'Ignoring ' .. attribute .. ' value "' .. colour .. '" for Typst output: ' ..
+      'not convertible to a hex code.'
+    )
+    return nil
   end
 
   if colour:match('^#') or colour:match('^rgb') or colour:match('^hsl') or colour:match('^hwb')
@@ -83,25 +115,6 @@ local function get_brand_colour(theme, colour, attribute)
     'expected a hex (#RGB/#RRGGBB), CSS function (rgb/hsl/hwb), named colour, ' ..
     'CSS var(), or brand colour name.'
   )
-  return nil
-end
-
---- Convert a colour reference to a 6-character hex (without leading "#") for LaTeX/Word/PowerPoint.
---- Brand-resolved values are already concrete; this normalises hex (3 or 6 digits) and named colours.
---- Returns nil for values that cannot be expressed as a hex code (rgb(), hsl(), CSS var(), Typst rgb()).
---- @param colour string|nil The colour value
---- @return string|nil A 6-character hex string without "#", or nil when not expressible as hex
-local function to_hex6(colour)
-  if colour == nil then return nil end
-  if colour_utils.is_named_colour(colour) then
-    return colour_utils.named_to_HTML(colour):gsub('^#', '')
-  end
-  if colour:match('^#%x%x%x%x%x%x$') then
-    return colour:sub(2)
-  end
-  if colour:match('^#%x%x%x$') then
-    return colour_utils.expand_hex_colour(colour):gsub('^#', '')
-  end
   return nil
 end
 

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -48,7 +48,7 @@ Where several spellings of the same attribute are given, the first in the alias 
 | --- | --- | --- |
 | Hex | `#b22222`, `#abc` | Every format. Three or six digits. |
 | Brand colour | `red`, `primary` | Every format. A name from the `color.palette` or the role names in `_brand.yml`. |
-| CSS named | `firebrick` | Every format except Typst. |
+| CSS named | `firebrick` | Every format. Converted to a hex code for Typst and the binary writers. |
 | CSS functional | `rgb(178 34 34)`, `hsl(0 71% 42%)`, `hwb(0 13% 30%)` | HTML and RevealJS. |
 | CSS custom property | `var(--brand-primary)` | HTML and RevealJS. Resolved by the browser rather than by the filter. |
 
@@ -56,13 +56,9 @@ Where several spellings of the same attribute are given, the first in the alias 
 
 LaTeX, Word, and PowerPoint need a colour they can write as a hex triplet, so a value they cannot convert is dropped with a warning and the rest of the styling is written without it.
 
-In HTML, LaTeX, Word, and PowerPoint an unrecognised colour is skipped with a warning rather than written out, so a typo cannot produce malformed LaTeX or broken CSS.
+An unrecognised colour is skipped with a warning rather than written out, so a typo cannot produce malformed output in any format.
 
-::: {.callout-caution}
-Typst is the exception, in both directions.
-It takes hex and brand colours only, and anything else is written as `rgb("…")`, which Typst rejects: a CSS named colour, a CSS functional colour, or a typo stops the render with `color string contains non-hexadecimal letters` rather than being skipped.
-Keep to hex or brand names in a document that renders to Typst.
-:::
+Typst takes a hex code, so a value is converted to one before it is written: a hex code of either length, a brand colour, and a CSS named colour all work, while a CSS functional colour cannot be expressed that way and is skipped with a warning.
 
 ### Brand colours
 


### PR DESCRIPTION
The Typst branch returned `rgb("<value>")` before the hex and named-colour checks, so an unusable value reached the compiler and stopped the render, where every other format warns and skips.

Typst takes a hex code, so validating alone is not enough. The value is converted first, which also makes a CSS named colour work there as it does elsewhere.

Verified with a document carrying five values, rendered before and after:

```
before: ERROR: color string contains non-hexadecimal letters, no PDF
after:  renders; firebrick -> rgb("#B22222"), #f00 -> rgb("#ff0000"), #441100 kept,
        rgb(178, 34, 34) and notacolour skipped with a warning
```

The reference is corrected: it had said a CSS named colour does not work under Typst and that an unusable value stops the render.