### PR TITLE
build: update the vendored Lua modules to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - docs: Serve the extension's social card as the Open Graph image, so a shared link shows the card rather than the first image on the page. (#87)
 
+### Refactoring
+
+- build: Update the vendored Lua modules to 2.3.0. A module no longer carries a version line in its header, so its checksum changes only when its code changes. (#88)
+
 ## 2.3.1 (2026-08-01)
 
 ### Bug Fixes

--- a/_extensions/highlight-text/_dependencies.yml
+++ b/_extensions/highlight-text/_dependencies.yml
@@ -3,12 +3,12 @@ sources:
   quarto-lua-modules:
     origin: "https://github.com/mcanouil/quarto-lua-modules"
     fetch: "{origin}/releases/download/{version}/{file}"
-    version: "2.1.0"
+    version: "2.3.0"
     licence: MIT
     files:
       colour.lua:
-        sha256: "b9b65bb0da43efbafda86732621bae4a92802884149d8a70b499613d23ccd15a"
+        sha256: "eab8e12368b1ea3ff91ae5919863d9d435be39674a63e1514c9778e60790ba03"
         runtime: any
       logging.lua:
-        sha256: "0c3ded6020d3739c91bb6a492328751b284d1ada5763a1b8ca6fc5536ac01c95"
+        sha256: "5d99ceb89c813fbe4491310e42b4a4cff62e11dda42f01b4f61f969aa58e0706"
         runtime: any

--- a/_extensions/highlight-text/_vendor/quarto-lua-modules/colour.lua
+++ b/_extensions/highlight-text/_vendor/quarto-lua-modules/colour.lua
@@ -3,7 +3,6 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.1.0
 
 local M = {}
 

--- a/_extensions/highlight-text/_vendor/quarto-lua-modules/logging.lua
+++ b/_extensions/highlight-text/_vendor/quarto-lua-modules/logging.lua
@@ -3,7 +3,6 @@
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
---- @version 2.1.0
 
 local M = {}
 


### PR DESCRIPTION
Updates the vendored Lua modules from 2.1.0 to 2.3.0 and repins each checksum.

The 2.3.0 release drops the `--- @version` line that every module carried. The release used to stamp that line at each version, so a module's bytes changed on every release even when its code did not, and a vendored copy could never match a later release by checksum. The manifest already records the version this extension took.

Verified with `vendor.sh --check`, which reports every declared source at the version its origin publishes.